### PR TITLE
Compilation adjustments for libcsprrpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     set(CMAKE_CXX_FLAGS "-Werror -Wno-missing-declarations -O3 -fPIC")
 endif()
 
-#TODO the rest of deps should be moved outside of the project too (if possible)
+# TODO the rest of deps should be moved outside of the project too (if possible)
 MESSAGE("using deps from vcpkg or system")
 find_package(Boost 1.75.0 REQUIRED)
 find_package(OpenSSL REQUIRED)
@@ -29,27 +29,29 @@ include_directories(
     ${Boost_INCLUDE_DIR}
 )
 
+if(NOT EXTERNAL_INCLUDES_DIR)
+    set(EXTERNAL_INCLUDES_DIR ${SDK_ROOT}/include)
+    file(MAKE_DIRECTORY ${EXTERNAL_INCLUDES_DIR})
+endif()
+
 add_subdirectory(lib/cryptopp-pem)
 add_subdirectory(src)
 
-#TODO maybe build for debug only
+# TODO maybe build for debug only
 IF(CASPER_SDK_TESTS)
-    MESSAGE ("building tests")
+    MESSAGE("building tests")
     enable_testing()
-    #TODO under linux gcc compiler crashes if we build both examples and tests; so build either this or that (memory exhaustion?)
-    #builds fine under windows
+
+    # TODO under linux gcc compiler crashes if we build both examples and tests; so build either this or that (memory exhaustion?)
+    # builds fine under windows
     add_subdirectory(test)
-    #add_subdirectory(examples)
+
+    # add_subdirectory(examples)
 endif()
 
 if(NOT LIBRARIES_DIR)
     set(LIBRARIES_DIR ${SDK_ROOT}/libs)
     file(MAKE_DIRECTORY ${LIBRARIES_DIR})
-endif()
-
-if(NOT EXTERNAL_INCLUDES_DIR)
-    set(EXTERNAL_INCLUDES_DIR ${SDK_ROOT}/include)
-    file(MAKE_DIRECTORY ${EXTERNAL_INCLUDES_DIR})
 endif()
 
 file(COPY "${SDK_ROOT}/src/include/" DESTINATION "${EXTERNAL_INCLUDES_DIR}/casper_sdk")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@ find_package(Boost 1.75.0 REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(CryptoPP REQUIRED)
 
+# We need ${CRYPTOPP_LIBRARIES} variable set, it is not set
+# by find_package + vcpkg in such a case just find it manually
+if(NOT CRYPTOPP_LIBRARIES)
+    find_library(CryptoPP_LIBRARY NAMES cryptopp-static cryptopp DOC "CryptoPP library")
+    set(CRYPTOPP_LIBRARIES ${CryptoPP_LIBRARY})
+endif()
+
 # Set the include paths.
 include_directories(
     src/include

--- a/lib/cryptopp-pem/CMakeLists.txt
+++ b/lib/cryptopp-pem/CMakeLists.txt
@@ -12,6 +12,6 @@ set(SOURCES
 add_library(cryptopp_pem STATIC ${SOURCES})
 target_include_directories(cryptopp_pem PUBLIC ${SRC_PATH})
 target_link_libraries(cryptopp_pem
-    PUBLIC 
-    cryptopp-static
+    PUBLIC
+    ${CRYPTOPP_LIBRARIES}
 )

--- a/lib/cryptopp-pem/cryptopp/x509cert.cpp
+++ b/lib/cryptopp-pem/cryptopp/x509cert.cpp
@@ -8,19 +8,19 @@
 //   http://www.cryptopp.com/wiki/PEM_Pack
 ///////////////////////////////////////////////////////////////////////////
 
-#include <cryptopp/pch.h>
-#include <cryptopp/cryptlib.h>
-#include <cryptopp/secblock.h>
 #include "x509cert.h"
-#include <cryptopp/integer.h>
-#include <cryptopp/files.h>
-#include <cryptopp/oids.h>
-#include <cryptopp/trap.h>
 
-#include <cryptopp/rsa.h>
+#include <cryptopp/cryptlib.h>
 #include <cryptopp/dsa.h>
-#include <cryptopp/pssr.h>
 #include <cryptopp/eccrypto.h>
+#include <cryptopp/files.h>
+#include <cryptopp/integer.h>
+#include <cryptopp/oids.h>
+#include <cryptopp/pch.h>
+#include <cryptopp/pssr.h>
+#include <cryptopp/rsa.h>
+#include <cryptopp/secblock.h>
+#include <cryptopp/trap.h>
 #include <cryptopp/xed25519.h>
 
 // For printing
@@ -30,514 +30,539 @@
 // For Validate
 #include <cryptopp/osrng.h>
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
 
 // Make these defines to avoid global objects
-#define id_basicConstraints            (OID(2)+5+29+19)
-#define id_authorityKeyIdentifier      (OID(2)+5+29+35)
-#define id_msUserPrincipalName         (OID(1)+3+6+1+4+1+311+20+2+3)
-#define id_subjectPublicKeyIdentifier  (OID(2)+5+29+14)
-#define id_distinguishedName           (OID(2)+5+4+49)
-#define id_commonName                  (OID(2)+5+4+3)
-#define id_uniqueIdentifier            (OID(2)+5+4+45)
-#define id_pkcsEmail                   (OID(1)+2+840+113549+1+9+1)
-#define id_subjectAltName              (OID(2)+5+29+17)
-#define id_netscapeServerName          (OID(2)+16+840+1+113730+1+12)
-#define id_keyUsage                    (OID(2)+5+29+15)
-#define id_extendedKeyUsage            (OID(2)+5+29+37)
+#define id_basicConstraints (OID(2) + 5 + 29 + 19)
+#define id_authorityKeyIdentifier (OID(2) + 5 + 29 + 35)
+#define id_msUserPrincipalName (OID(1) + 3 + 6 + 1 + 4 + 1 + 311 + 20 + 2 + 3)
+#define id_subjectPublicKeyIdentifier (OID(2) + 5 + 29 + 14)
+#define id_distinguishedName (OID(2) + 5 + 4 + 49)
+#define id_commonName (OID(2) + 5 + 4 + 3)
+#define id_uniqueIdentifier (OID(2) + 5 + 4 + 45)
+#define id_pkcsEmail (OID(1) + 2 + 840 + 113549 + 1 + 9 + 1)
+#define id_subjectAltName (OID(2) + 5 + 29 + 17)
+#define id_netscapeServerName (OID(2) + 16 + 840 + 1 + 113730 + 1 + 12)
+#define id_keyUsage (OID(2) + 5 + 29 + 15)
+#define id_extendedKeyUsage (OID(2) + 5 + 29 + 37)
 
 ANONYMOUS_NAMESPACE_BEGIN
 
 using namespace CryptoPP;
 
-class SecByteBlockSink : public Bufferless<Sink>
-{
-public:
-    SecByteBlockSink(SecByteBlock &block) : m_block(block) { }
+class SecByteBlockSink : public Bufferless<Sink> {
+ public:
+  SecByteBlockSink(SecByteBlock& block) : m_block(block) {}
 
-    size_t Put2(const byte *inString, size_t length, int, bool)
-    {
-        if(!inString || !length) return length;
+  size_t Put2(const byte* inString, size_t length, int, bool) {
+    if (!inString || !length) return length;
 
-        size_t currentSize = m_block.size();
-        m_block.Grow(currentSize+length);
-        std::memcpy(m_block+currentSize, inString, length);
+    size_t currentSize = m_block.size();
+    m_block.Grow(currentSize + length);
+    std::memcpy(m_block + currentSize, inString, length);
 
-        return 0;
-    }
+    return 0;
+  }
 
-private:
-    SecByteBlock& m_block;
+ private:
+  SecByteBlock& m_block;
 };
 
-bool HasOptionalAttribute(const BufferedTransformation &bt, byte tag)
-{
-    byte b;
-    if (bt.Peek(b) && b == tag)
-        return true;
-    return false;
+bool HasOptionalAttribute(const BufferedTransformation& bt, byte tag) {
+  byte b;
+  if (bt.Peek(b) && b == tag) return true;
+  return false;
 }
 
-inline bool IsRSAAlgorithm(const OID& alg)
-{
-    return alg == ASN1::rsaEncryption() ||    // rsaEncryption is most popular in spki
-         alg == OID(1)+2+840+113549+1+1+10 || // RSA-PSS
-        (alg >= ASN1::rsaEncryption() && alg <= ASN1::sha512_256WithRSAEncryption());
+inline bool IsRSAAlgorithm(const OID& alg) {
+  return alg ==
+             ASN1::rsaEncryption() ||  // rsaEncryption is most popular in spki
+         alg == OID(1) + 2 + 840 + 113549 + 1 + 1 + 10 ||  // RSA-PSS
+         (alg >= ASN1::rsaEncryption() &&
+          alg <= ASN1::sha512_256WithRSAEncryption());
 }
 
-inline bool IsDSAAlgorithm(const OID& alg)
-{
-    return alg == ASN1::id_dsa();
+inline bool IsDSAAlgorithm(const OID& alg) { return alg == ASN1::id_dsa(); }
+
+inline bool IsECDSAAlgorithm(const OID& alg) {
+  return alg == id_ecdsaWithSHA1 || alg == id_ecdsaWithSHA256 ||
+         alg == id_ecdsaWithSHA384 || alg == id_ecdsaWithSHA512;
 }
 
-inline bool IsECDSAAlgorithm(const OID& alg)
-{
-    return alg == id_ecdsaWithSHA1 || alg == id_ecdsaWithSHA256 ||
-        alg == id_ecdsaWithSHA384 || alg == id_ecdsaWithSHA512;
+inline bool IsEd25519Algorithm(const OID& alg) {
+  // PKIX uses OID 1.3.6.1.4.1.11591.15.1 and calls it curve25519.
+  // See https://datatracker.ietf.org/doc/html/draft-josefsson-pkix-newcurves
+  // OpenPGP and GNU use the OID to indicate Ed25519 signing.
+  // See https://www.gnupg.org/oids.html,
+  // https://www.gnu.org/prep/standards/html_node/OID-Allocations.html,
+  // https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-rfc4880bis
+  return alg == ASN1::Ed25519() ||
+         alg == OID(1) + 3 + 6 + 1 + 4 + 1 + 11591 + 15 + 1;
 }
 
-inline bool IsEd25519Algorithm(const OID& alg)
-{
-    // PKIX uses OID 1.3.6.1.4.1.11591.15.1 and calls it curve25519.
-    // See https://datatracker.ietf.org/doc/html/draft-josefsson-pkix-newcurves
-    // OpenPGP and GNU use the OID to indicate Ed25519 signing.
-    // See https://www.gnupg.org/oids.html,
-    // https://www.gnu.org/prep/standards/html_node/OID-Allocations.html,
-    // https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-rfc4880bis
-    return alg == ASN1::Ed25519() || alg == OID(1)+3+6+1+4+1+11591+15+1;
+inline bool IsECPrimeFieldAlgorithm(const OID& alg, const OID& field) {
+  if (alg != ASN1::id_ecPublicKey()) return false;
+
+  return field == ASN1::prime_field() ||
+         (field >= ASN1::secp112r1() && field <= ASN1::secp521r1()) ||
+         (field >= ASN1::secp192r1() &&
+          field <= ASN1::secp256r1()) ||  // not a typo
+         (field >= ASN1::brainpoolP160r1() && field <= ASN1::brainpoolP512r1());
 }
 
-inline bool IsECPrimeFieldAlgorithm(const OID& alg, const OID& field)
-{
-    if (alg != ASN1::id_ecPublicKey())
-        return false;
+inline bool IsECBinaryFieldAlgorithm(const OID& alg, const OID& field) {
+  if (alg != ASN1::id_ecPublicKey()) return false;
 
-    return field == ASN1::prime_field() ||
-        (field >= ASN1::secp112r1() && field <= ASN1::secp521r1()) ||
-        (field >= ASN1::secp192r1() && field <= ASN1::secp256r1()) ||  // not a typo
-        (field >= ASN1::brainpoolP160r1() && field <= ASN1::brainpoolP512r1());
-}
-
-inline bool IsECBinaryFieldAlgorithm(const OID& alg, const OID& field)
-{
-    if (alg != ASN1::id_ecPublicKey())
-        return false;
-
-    return field == ASN1::characteristic_two_field();
+  return field == ASN1::characteristic_two_field();
 }
 
 ANONYMOUS_NAMESPACE_END
 
 NAMESPACE_BEGIN(CryptoPP)
 
-struct OidToName
-{
-    virtual ~OidToName() {};
-    OidToName (const OID& o, const std::string& n) : oid(o), name(n) {}
+struct OidToName {
+  virtual ~OidToName(){};
+  OidToName(const OID& o, const std::string& n) : oid(o), name(n) {}
 
-    OID oid;
-    std::string name;
+  OID oid;
+  std::string name;
 };
 
-struct OidToNameCompare
-{
-    bool operator() (const OidToName& first, const OidToName& second)
-        { return (first.oid < second.oid); }
+struct OidToNameCompare {
+  bool operator()(const OidToName& first, const OidToName& second) {
+    return (first.oid < second.oid);
+  }
 };
 
 typedef std::vector<OidToName> OidToNameArray;
 
-OidToNameArray GetOidToNameTable()
-{
-    // The names are mostly standard. Also see the various RFCs, and
-    // X.520, Section 6, for a partial list of LDAP Names,
-    // https://www.itu.int/rec/T-REC-X.520, and
-    // https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml
-    OidToNameArray table;
-    table.reserve(96);
+OidToNameArray GetOidToNameTable() {
+  // The names are mostly standard. Also see the various RFCs, and
+  // X.520, Section 6, for a partial list of LDAP Names,
+  // https://www.itu.int/rec/T-REC-X.520, and
+  // https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml
+  OidToNameArray table;
+  table.reserve(96);
 
-    table.push_back(OidToName(OID(1)+2+840+10045+2+1,   "ecPublicKey"));
-    table.push_back(OidToName(OID(1)+2+840+10045+3+1+1, "secp192v1"));
-    table.push_back(OidToName(OID(1)+2+840+10045+3+1+2, "secp192v2"));
-    table.push_back(OidToName(OID(1)+2+840+10045+3+1+3, "secp192v3"));
-    table.push_back(OidToName(id_secp256v1, "secp256v1"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 10045 + 2 + 1, "ecPublicKey"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 10045 + 3 + 1 + 1, "secp192v1"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 10045 + 3 + 1 + 2, "secp192v2"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 10045 + 3 + 1 + 3, "secp192v3"));
+  table.push_back(OidToName(id_secp256v1, "secp256v1"));
 
-    table.push_back(OidToName(id_ecdsaWithSHA1,   "ecdsaWithSHA1"));
-    table.push_back(OidToName(id_ecdsaWithSHA256, "ecdsaWithSHA256"));
-    table.push_back(OidToName(id_ecdsaWithSHA384, "ecdsaWithSHA384"));
-    table.push_back(OidToName(id_ecdsaWithSHA512, "ecdsaWithSHA512"));
+  table.push_back(OidToName(id_ecdsaWithSHA1, "ecdsaWithSHA1"));
+  table.push_back(OidToName(id_ecdsaWithSHA256, "ecdsaWithSHA256"));
+  table.push_back(OidToName(id_ecdsaWithSHA384, "ecdsaWithSHA384"));
+  table.push_back(OidToName(id_ecdsaWithSHA512, "ecdsaWithSHA512"));
 
-    table.push_back(OidToName(OID(1)+3+132+0+33, "secp224r1"));
-    table.push_back(OidToName(OID(1)+3+132+0+34, "secp384r1"));
-    table.push_back(OidToName(OID(1)+3+132+0+35, "secp521r1"));
+  table.push_back(OidToName(OID(1) + 3 + 132 + 0 + 33, "secp224r1"));
+  table.push_back(OidToName(OID(1) + 3 + 132 + 0 + 34, "secp384r1"));
+  table.push_back(OidToName(OID(1) + 3 + 132 + 0 + 35, "secp521r1"));
 
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+1, "rsaEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+2, "md2WithRSAEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+3, "md4WithRSAEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+4, "md5WithRSAEncryption"));
-    table.push_back(OidToName(id_sha1WithRSASignature,   "sha1WithRSASignature"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+6, "rsaOAEPEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+7, "rsaAESOAEP"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+10, "rsaSSAPSS"));
-    table.push_back(OidToName(id_sha256WithRSAEncryption, "sha256WithRSAEncryption"));
-    table.push_back(OidToName(id_sha384WithRSAEncryption, "sha384WithRSAEncryption"));
-    table.push_back(OidToName(id_sha512WithRSAEncryption, "sha512WithRSAEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+14, "sha224WithRSAEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+15, "sha512-224WithRSAEncryption"));
-    table.push_back(OidToName(OID(1)+2+840+113549+1+1+16, "sha512-256WithRSAEncryption"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 1, "rsaEncryption"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 2, "md2WithRSAEncryption"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 3, "md4WithRSAEncryption"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 4, "md5WithRSAEncryption"));
+  table.push_back(OidToName(id_sha1WithRSASignature, "sha1WithRSASignature"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 6, "rsaOAEPEncryption"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 7, "rsaAESOAEP"));
+  table.push_back(
+      OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 10, "rsaSSAPSS"));
+  table.push_back(
+      OidToName(id_sha256WithRSAEncryption, "sha256WithRSAEncryption"));
+  table.push_back(
+      OidToName(id_sha384WithRSAEncryption, "sha384WithRSAEncryption"));
+  table.push_back(
+      OidToName(id_sha512WithRSAEncryption, "sha512WithRSAEncryption"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 14,
+                            "sha224WithRSAEncryption"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 15,
+                            "sha512-224WithRSAEncryption"));
+  table.push_back(OidToName(OID(1) + 2 + 840 + 113549 + 1 + 1 + 16,
+                            "sha512-256WithRSAEncryption"));
 
-    table.push_back(OidToName(id_commonName,  "CN"));     // Common name
-    table.push_back(OidToName(OID(2)+5+4+ 4,  "SN"));     // Surname
-    table.push_back(OidToName(OID(2)+5+4+ 5,  "SERIALNUMBER"));  // Serial number
-    table.push_back(OidToName(OID(2)+5+4+ 6,  "C"));      // Country, ISO 3166-1 alpha-2
-    table.push_back(OidToName(OID(2)+5+4+ 7,  "L"));      // Locality
-    table.push_back(OidToName(OID(2)+5+4+ 8,  "ST"));     // State or province
-    table.push_back(OidToName(OID(2)+5+4+ 9,  "STREET")); // Street address
-    table.push_back(OidToName(OID(2)+5+4+10,  "O"));      // Organization
-    table.push_back(OidToName(OID(2)+5+4+11,  "OU"));     // Organization unit
-    table.push_back(OidToName(OID(2)+5+4+12,  "TITLE"));  // Title
-    table.push_back(OidToName(OID(2)+5+4+13,  "DESCRIPTION"));    // Description
-    table.push_back(OidToName(OID(2)+5+4+16,  "POSTALADDRESS"));  // Postal address
-    table.push_back(OidToName(OID(2)+5+4+17,  "POSTALCODE"));     // Postal code
-    table.push_back(OidToName(OID(2)+5+4+18,  "POSTOFFICEBOX"));  // Postal office box
-    table.push_back(OidToName(OID(2)+5+4+20,  "TEL"));    // Phone number
-    table.push_back(OidToName(OID(2)+5+4+23,  "FAX"));    // Fax number
-    table.push_back(OidToName(OID(2)+5+4+31,  "MEMBER")); // Member, names associated with object
-    table.push_back(OidToName(OID(2)+5+4+32,  "OWNER"));  // Owner/responsibility
-    table.push_back(OidToName(OID(2)+5+4+35,   "USERPASSWORD"));        // User password
-    table.push_back(OidToName(OID(2)+5+4+35+2, "ENCUSERPASSWORD"));     // Encrypted user password
-    table.push_back(OidToName(OID(2)+5+4+36,   "USERCERTIFICATE"));     // User certificate
-    table.push_back(OidToName(OID(2)+5+4+36+2, "ENCUSERCERTIFICATE"));  // Encrypted user certificate
-    table.push_back(OidToName(OID(2)+5+4+37,   "CACERTIFICATE"));       // CA certificate
-    table.push_back(OidToName(OID(2)+5+4+37+2, "ENCCACERTIFICATE"));    // Encrypted CA certificate
-    table.push_back(OidToName(OID(2)+5+4+41,  "NAME"));      // Name
-    table.push_back(OidToName(OID(2)+5+4+42,  "GIVENNAME")); // Given name
-    table.push_back(OidToName(OID(2)+5+4+43,  "INITIALS"));  // Initials
-    table.push_back(OidToName(OID(2)+5+4+44,  "GENERATION"));  // Generation qualifier+ Jr.+ Sr.+ etc
-    table.push_back(OidToName(id_uniqueIdentifier, "UID"));    // X.500 Unique identifier
-    table.push_back(OidToName(OID(2)+5+4+46,  "DNQUALIFIER")); // Distinguished name qualifier
-    table.push_back(OidToName(OID(2)+5+4+48,  "PROTOCOL"));    // Protocol information
-    table.push_back(OidToName(OID(2)+5+4+49,  "DN"));          // Distinguished name
-    table.push_back(OidToName(OID(2)+5+4+50,  "UNIQUEMEMBER"));// Unique member
-    table.push_back(OidToName(OID(2)+5+4+51,  "HOUSE"));       // House identifier
-    table.push_back(OidToName(OID(2)+5+4+65,  "PSEUDONYM"));   // Pseudonym
-    table.push_back(OidToName(OID(2)+5+4+78,  "OID"));         // Object identifier
-    table.push_back(OidToName(OID(2)+5+4+83,  "URI"));         // Uniform Resource Identifier, RFC 3986
-    table.push_back(OidToName(OID(2)+5+4+85,  "USERPWD"));     // URI user password
-    table.push_back(OidToName(OID(2)+5+4+86,  "URN"));         // Uniform Resource Name, RFC 3406
-    table.push_back(OidToName(OID(2)+5+4+87,  "URL"));         // Uniform Resource Locator
-    table.push_back(OidToName(OID(2)+5+4+98,  "C3"));          // 3-letter Country, ISO 3166-1 alpha-3
-    table.push_back(OidToName(OID(2)+5+4+99,  "N3"));          // 3-digit Country, ISO 3166-1 numeric-3
+  table.push_back(OidToName(id_commonName, "CN"));       // Common name
+  table.push_back(OidToName(OID(2) + 5 + 4 + 4, "SN"));  // Surname
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 5, "SERIALNUMBER"));  // Serial number
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 6, "C"));  // Country, ISO 3166-1 alpha-2
+  table.push_back(OidToName(OID(2) + 5 + 4 + 7, "L"));   // Locality
+  table.push_back(OidToName(OID(2) + 5 + 4 + 8, "ST"));  // State or province
+  table.push_back(OidToName(OID(2) + 5 + 4 + 9, "STREET"));  // Street address
+  table.push_back(OidToName(OID(2) + 5 + 4 + 10, "O"));      // Organization
+  table.push_back(OidToName(OID(2) + 5 + 4 + 11, "OU"));  // Organization unit
+  table.push_back(OidToName(OID(2) + 5 + 4 + 12, "TITLE"));  // Title
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 13, "DESCRIPTION"));  // Description
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 16, "POSTALADDRESS"));  // Postal address
+  table.push_back(OidToName(OID(2) + 5 + 4 + 17, "POSTALCODE"));  // Postal code
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 18, "POSTOFFICEBOX"));    // Postal office box
+  table.push_back(OidToName(OID(2) + 5 + 4 + 20, "TEL"));  // Phone number
+  table.push_back(OidToName(OID(2) + 5 + 4 + 23, "FAX"));  // Fax number
+  table.push_back(OidToName(OID(2) + 5 + 4 + 31,
+                            "MEMBER"));  // Member, names associated with object
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 32, "OWNER"));  // Owner/responsibility
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 35, "USERPASSWORD"));  // User password
+  table.push_back(OidToName(OID(2) + 5 + 4 + 35 + 2,
+                            "ENCUSERPASSWORD"));  // Encrypted user password
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 36, "USERCERTIFICATE"));  // User certificate
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 36 + 2,
+                "ENCUSERCERTIFICATE"));  // Encrypted user certificate
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 37, "CACERTIFICATE"));  // CA certificate
+  table.push_back(OidToName(OID(2) + 5 + 4 + 37 + 2,
+                            "ENCCACERTIFICATE"));  // Encrypted CA certificate
+  table.push_back(OidToName(OID(2) + 5 + 4 + 41, "NAME"));       // Name
+  table.push_back(OidToName(OID(2) + 5 + 4 + 42, "GIVENNAME"));  // Given name
+  table.push_back(OidToName(OID(2) + 5 + 4 + 43, "INITIALS"));   // Initials
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 44,
+                "GENERATION"));  // Generation qualifier+ Jr.+ Sr.+ etc
+  table.push_back(
+      OidToName(id_uniqueIdentifier, "UID"));  // X.500 Unique identifier
+  table.push_back(OidToName(OID(2) + 5 + 4 + 46,
+                            "DNQUALIFIER"));  // Distinguished name qualifier
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 48, "PROTOCOL"));  // Protocol information
+  table.push_back(OidToName(OID(2) + 5 + 4 + 49, "DN"));  // Distinguished name
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 50, "UNIQUEMEMBER"));       // Unique member
+  table.push_back(OidToName(OID(2) + 5 + 4 + 51, "HOUSE"));  // House identifier
+  table.push_back(OidToName(OID(2) + 5 + 4 + 65, "PSEUDONYM"));  // Pseudonym
+  table.push_back(OidToName(OID(2) + 5 + 4 + 78, "OID"));  // Object identifier
+  table.push_back(OidToName(OID(2) + 5 + 4 + 83,
+                            "URI"));  // Uniform Resource Identifier, RFC 3986
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 85, "USERPWD"));  // URI user password
+  table.push_back(OidToName(OID(2) + 5 + 4 + 86,
+                            "URN"));  // Uniform Resource Name, RFC 3406
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 87, "URL"));  // Uniform Resource Locator
+  table.push_back(OidToName(OID(2) + 5 + 4 + 98,
+                            "C3"));  // 3-letter Country, ISO 3166-1 alpha-3
+  table.push_back(OidToName(OID(2) + 5 + 4 + 99,
+                            "N3"));  // 3-digit Country, ISO 3166-1 numeric-3
 
-    table.push_back(OidToName(OID(2)+5+4+100, "DOMAINNAME"));  // Domain name, RFC 5890
+  table.push_back(
+      OidToName(OID(2) + 5 + 4 + 100, "DOMAINNAME"));  // Domain name, RFC 5890
 
-    table.push_back(OidToName(id_subjectPublicKeyIdentifier, "SPKI")); // Subject public key identifier
-    table.push_back(OidToName(id_keyUsage, "KU"));                     // Key use
-    table.push_back(OidToName(id_subjectAltName, "SAN"));              // Subject alternate names
-    table.push_back(OidToName(id_basicConstraints, "BC"));             // Basic constraints
-    table.push_back(OidToName(OID(2)+5+29+30, "NC"));                  // Name constraints
-    table.push_back(OidToName(id_authorityKeyIdentifier, "AKI"));      // Authority key identifier
-    table.push_back(OidToName(id_extendedKeyUsage, "EKU"));            // Extended key use
+  table.push_back(OidToName(id_subjectPublicKeyIdentifier,
+                            "SPKI"));  // Subject public key identifier
+  table.push_back(OidToName(id_keyUsage, "KU"));  // Key use
+  table.push_back(
+      OidToName(id_subjectAltName, "SAN"));  // Subject alternate names
+  table.push_back(OidToName(id_basicConstraints, "BC"));   // Basic constraints
+  table.push_back(OidToName(OID(2) + 5 + 29 + 30, "NC"));  // Name constraints
+  table.push_back(
+      OidToName(id_authorityKeyIdentifier, "AKI"));  // Authority key identifier
+  table.push_back(OidToName(id_extendedKeyUsage, "EKU"));  // Extended key use
 
-    table.push_back(OidToName(id_netscapeServerName, "ssl-server-name"));   // Netscape server name
-    table.push_back(OidToName(OID(2)+16+840+1+113730+1+13, "ns-comment"));  // Netscape comment
+  table.push_back(OidToName(id_netscapeServerName,
+                            "ssl-server-name"));  // Netscape server name
+  table.push_back(OidToName(OID(2) + 16 + 840 + 1 + 113730 + 1 + 13,
+                            "ns-comment"));  // Netscape comment
 
-    table.push_back(OidToName(OID(0)+9+2342+19200300+100+1+1, "UID"));   // User Id
-    table.push_back(OidToName(OID(0)+9+2342+19200300+100+1+25, "DC"));   // Domain component
-    table.push_back(OidToName(id_pkcsEmail, "EMAIL"));          // Email address+ part of DN+ deprecated
-    table.push_back(OidToName(id_msUserPrincipalName, "UPN"));  // Microsoft User Principal Name (UPN)
-                                                                // Found in the SAN as [1] otherName
+  table.push_back(
+      OidToName(OID(0) + 9 + 2342 + 19200300 + 100 + 1 + 1, "UID"));  // User Id
+  table.push_back(OidToName(OID(0) + 9 + 2342 + 19200300 + 100 + 1 + 25,
+                            "DC"));  // Domain component
+  table.push_back(OidToName(id_pkcsEmail,
+                            "EMAIL"));  // Email address+ part of DN+ deprecated
+  table.push_back(OidToName(id_msUserPrincipalName,
+                            "UPN"));  // Microsoft User Principal Name (UPN)
+                                      // Found in the SAN as [1] otherName
 
-    std::sort(table.begin(), table.end(), OidToNameCompare());
+  std::sort(table.begin(), table.end(), OidToNameCompare());
 
-    return table;
+  return table;
 }
 
-std::string OidToNameLookup(const OID& oid, const char *defaultName)
-{
-    static const OidToNameArray table = GetOidToNameTable();
+std::string OidToNameLookup(const OID& oid, const char* defaultName) {
+  static const OidToNameArray table = GetOidToNameTable();
 
-    // Binary search
-    size_t first  = 0;
-    size_t last   = table.size() - 1;
-    size_t middle = (first+last)/2;
+  // Binary search
+  size_t first = 0;
+  size_t last = table.size() - 1;
+  size_t middle = (first + last) / 2;
 
-    while (first <= last)
-    {
-        if (table[middle].oid < oid)
-        {
-            first = middle + 1;
-        }
-        else if (table[middle].oid == oid)
-        {
-            return table[middle].name;
-        }
-        else
-            last = middle - 1;
+  while (first <= last) {
+    if (table[middle].oid < oid) {
+      first = middle + 1;
+    } else if (table[middle].oid == oid) {
+      return table[middle].name;
+    } else
+      last = middle - 1;
 
-        middle = (first + last)/2;
-    }
+    middle = (first + last) / 2;
+  }
 
-    // Not found, return defaultName.
-    if (defaultName != NULLPTR)
-        return defaultName;
+  // Not found, return defaultName.
+  if (defaultName != NULLPTR) return defaultName;
 
-    std::ostringstream oss;
-    oss << oid;
-    return oss.str();
+  std::ostringstream oss;
+  oss << oid;
+  return oss.str();
 }
 
 // Forward declaration
 struct KeyUsageValue;
 
-struct OidToKeyUsageValue
-{
-    virtual ~OidToKeyUsageValue() {};
-    OidToKeyUsageValue (const OID& o, const KeyUsageValue::KeyUsageEnum& v) : oid(o), ku(v) {}
+struct OidToKeyUsageValue {
+  virtual ~OidToKeyUsageValue(){};
+  OidToKeyUsageValue(const OID& o, const KeyUsageValue::KeyUsageEnum& v)
+      : oid(o), ku(v) {}
 
-    OID oid;
-    KeyUsageValue::KeyUsageEnum ku;
+  OID oid;
+  KeyUsageValue::KeyUsageEnum ku;
 };
 
-struct OidToKeyUsageCompare
-{
-    bool operator() (const OidToKeyUsageValue& first, const OidToKeyUsageValue& second)
-        { return (first.oid < second.oid); }
+struct OidToKeyUsageCompare {
+  bool operator()(const OidToKeyUsageValue& first,
+                  const OidToKeyUsageValue& second) {
+    return (first.oid < second.oid);
+  }
 };
 
 typedef std::vector<OidToKeyUsageValue> OidToKeyUsageValueArray;
 
-OidToKeyUsageValueArray GetOidToKeyUsageValueTable()
-{
-    OidToKeyUsageValueArray table;
-    table.reserve(24);
+OidToKeyUsageValueArray GetOidToKeyUsageValueTable() {
+  OidToKeyUsageValueArray table;
+  table.reserve(24);
 
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+1, KeyUsageValue::serverAuth));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+2, KeyUsageValue::clientAuth));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+3, KeyUsageValue::codeSigning));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+4, KeyUsageValue::emailProtection));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+5, KeyUsageValue::ipsecEndSystem));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+6, KeyUsageValue::ipsecTunnel));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+7, KeyUsageValue::ipsecUser));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+8, KeyUsageValue::timeStamping));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+9, KeyUsageValue::OCSPSigning));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+10, KeyUsageValue::dvcs));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+13, KeyUsageValue::eapOverPPP));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+14, KeyUsageValue::eapOverLAN));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+17, KeyUsageValue::ipsecIKE));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+20, KeyUsageValue::sipDomain));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+21, KeyUsageValue::secureShellClient));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+22, KeyUsageValue::secureShellServer));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+27, KeyUsageValue::cmcCA));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+28, KeyUsageValue::cmcRA));
-    table.push_back(OidToKeyUsageValue(OID(1)+3+6+1+5+5+7+3+29, KeyUsageValue::cmcArchive));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 1,
+                                     KeyUsageValue::serverAuth));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 2,
+                                     KeyUsageValue::clientAuth));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 3,
+                                     KeyUsageValue::codeSigning));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 4,
+                                     KeyUsageValue::emailProtection));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 5,
+                                     KeyUsageValue::ipsecEndSystem));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 6,
+                                     KeyUsageValue::ipsecTunnel));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 7,
+                                     KeyUsageValue::ipsecUser));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 8,
+                                     KeyUsageValue::timeStamping));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 9,
+                                     KeyUsageValue::OCSPSigning));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 10,
+                                     KeyUsageValue::dvcs));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 13,
+                                     KeyUsageValue::eapOverPPP));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 14,
+                                     KeyUsageValue::eapOverLAN));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 17,
+                                     KeyUsageValue::ipsecIKE));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 20,
+                                     KeyUsageValue::sipDomain));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 21,
+                                     KeyUsageValue::secureShellClient));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 22,
+                                     KeyUsageValue::secureShellServer));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 27,
+                                     KeyUsageValue::cmcCA));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 28,
+                                     KeyUsageValue::cmcRA));
+  table.push_back(OidToKeyUsageValue(OID(1) + 3 + 6 + 1 + 5 + 5 + 7 + 3 + 29,
+                                     KeyUsageValue::cmcArchive));
 
-    return table;
+  return table;
 }
 
-KeyUsageValue::KeyUsageEnum OidToKeyUsageValueLookup(const OID& oid, KeyUsageValue::KeyUsageEnum defaultValue)
-{
-    static const OidToKeyUsageValueArray table = GetOidToKeyUsageValueTable();
+KeyUsageValue::KeyUsageEnum OidToKeyUsageValueLookup(
+    const OID& oid, KeyUsageValue::KeyUsageEnum defaultValue) {
+  static const OidToKeyUsageValueArray table = GetOidToKeyUsageValueTable();
 
-    // Binary search
-    size_t first  = 0;
-    size_t last   = table.size() - 1;
-    size_t middle = (first+last)/2;
+  // Binary search
+  size_t first = 0;
+  size_t last = table.size() - 1;
+  size_t middle = (first + last) / 2;
 
-    while (first <= last)
-    {
-        if (table[middle].oid < oid)
-        {
-            first = middle + 1;
-        }
-        else if (table[middle].oid == oid)
-        {
-            return table[middle].ku;
-        }
-        else
-            last = middle - 1;
+  while (first <= last) {
+    if (table[middle].oid < oid) {
+      first = middle + 1;
+    } else if (table[middle].oid == oid) {
+      return table[middle].ku;
+    } else
+      last = middle - 1;
 
-        middle = (first + last)/2;
-    }
+    middle = (first + last) / 2;
+  }
 
-    // Not found, return defaultValue
-    return defaultValue;
+  // Not found, return defaultValue
+  return defaultValue;
 }
 
-void RdnValue::BERDecode(BufferedTransformation &bt)
-{
-    BERSequenceDecoder seq(bt);
+void RdnValue::BERDecode(BufferedTransformation& bt) {
+  BERSequenceDecoder seq(bt);
 
-      m_oid.BERDecode(seq);
+  m_oid.BERDecode(seq);
 
-      byte b;
-      if (seq.Peek(b) && ValidateTag(b))
-      {
-          m_tag = static_cast<ASNTag>(b);
-          BERDecodeTextString(seq, m_value, b);
-      }
-      else
-          BERDecodeError();
+  byte b;
+  if (seq.Peek(b) && ValidateTag(b)) {
+    m_tag = static_cast<ASNTag>(b);
+    BERDecodeTextString(seq, m_value, b);
+  } else
+    BERDecodeError();
 
-    seq.MessageEnd();
+  seq.MessageEnd();
 }
 
-void RdnValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
+void RdnValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
 
-    // TODO: Implement this function
-    throw NotImplemented("RdnValue::DEREncode");
+  // TODO: Implement this function
+  throw NotImplemented("RdnValue::DEREncode");
 }
 
-bool RdnValue::ValidateTag(byte tag) const
-{
-    if (tag == UTF8_STRING || tag == NUMERIC_STRING || tag == PRINTABLE_STRING ||
-        tag == T61_STRING || tag == VIDEOTEXT_STRING || tag == IA5_STRING ||
-        tag == VISIBLE_STRING || tag == GENERAL_STRING || tag == UNIVERSAL_STRING ||
-        tag == BMP_STRING)
-        return true;
-    return false;
-}
-
-std::ostream& RdnValue::Print(std::ostream& out) const
-{
-    if (m_value.empty())
-        { return out; }
-
-    std::ostringstream oss;
-    oss << OidToNameLookup(m_oid);
-    oss << "=";
-    oss << EncodeValue();
-
-    return out << oss.str();
-}
-
-std::string RdnValue::EncodeValue() const
-{
-    if (m_value.empty())
-        { return "\"\""; }
-
-    bool quote = std::find(m_value.begin(), m_value.end(), byte(' ')) != m_value.end();
-
-    std::string val;
-    if (quote) val += "\"";
-    val.append((const char*)ConstBytePtr(m_value), BytePtrSize(m_value));
-    if (quote) val += "\"";
-
-    return val;
-}
-
-void DateValue::BERDecode(BufferedTransformation &bt)
-{
-    byte b;
-    if (bt.Peek(b) && ValidateTag(b))
-    {
-        m_tag = static_cast<ASNTag>(b);
-        BERDecodeDate(bt, m_value, b);
-    }
-    else
-        BERDecodeError();
-}
-
-void DateValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
-
-    // TODO: Implement this function
-    throw NotImplemented("DateValue::DEREncode");
-}
-
-bool DateValue::ValidateTag(byte tag) const
-{
-    if (tag == UTC_TIME || tag == GENERALIZED_TIME)
-        return true;
-    return false;
-}
-
-std::ostream& DateValue::Print(std::ostream& out) const
-{
-    if (m_value.empty())
-        { return out; }
-
-    return out << EncodeValue();
-}
-
-std::string DateValue::EncodeValue() const
-{
-    if (m_value.empty())
-        { return ""; }
-
-    return std::string((const char*)ConstBytePtr(m_value), BytePtrSize(m_value));
-}
-
-void ExtensionValue::BERDecode(BufferedTransformation &bt)
-{
-    BERSequenceDecoder seq(bt);
-      m_oid.BERDecode(seq);
-
-      m_critical = false;
-      if (HasOptionalAttribute(seq, BOOLEAN))
-      {
-          word32 flag;
-          BERDecodeUnsigned(seq, flag, BOOLEAN);
-          m_critical = !!flag;
-      }
-
-      BERDecodeOctetString(seq, m_value);
-
-    seq.MessageEnd();
-}
-
-void ExtensionValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
-
-    // TODO: Implement this function
-    throw NotImplemented("ExtensionValue::DEREncode");
-}
-
-bool ExtensionValue::ValidateTag(byte tag) const
-{
-    CRYPTOPP_UNUSED(tag);
+bool RdnValue::ValidateTag(byte tag) const {
+  if (tag == UTF8_STRING || tag == NUMERIC_STRING || tag == PRINTABLE_STRING ||
+      tag == T61_STRING || tag == VIDEOTEXT_STRING || tag == IA5_STRING ||
+      tag == VISIBLE_STRING || tag == GENERAL_STRING ||
+      tag == UNIVERSAL_STRING || tag == BMP_STRING)
     return true;
+  return false;
 }
 
-std::ostream& ExtensionValue::Print(std::ostream& out) const
-{
-    if (m_value.empty())
-        { return out; }
+std::ostream& RdnValue::Print(std::ostream& out) const {
+  if (m_value.empty()) {
+    return out;
+  }
 
-    return out << EncodeValue();
+  std::ostringstream oss;
+  oss << OidToNameLookup(m_oid);
+  oss << "=";
+  oss << EncodeValue();
+
+  return out << oss.str();
 }
 
-std::string ExtensionValue::EncodeValue() const
-{
-    // TODO: Implement this function
-    throw NotImplemented("ExtensionValue::EncodeValue");
+std::string RdnValue::EncodeValue() const {
+  if (m_value.empty()) {
+    return "\"\"";
+  }
+
+  bool quote =
+      std::find(m_value.begin(), m_value.end(), byte(' ')) != m_value.end();
+
+  std::string val;
+  if (quote) val += "\"";
+  val.append((const char*)ConstBytePtr(m_value), BytePtrSize(m_value));
+  if (quote) val += "\"";
+
+  return val;
 }
 
-void KeyIdentifierValue::BERDecode(BufferedTransformation &bt)
-{
-    byte tag;
-    if (!bt.Peek(tag) || !ValidateTag(tag))
-        BERDecodeError();
+void DateValue::BERDecode(BufferedTransformation& bt) {
+  byte b;
+  if (bt.Peek(b) && ValidateTag(b)) {
+    m_tag = static_cast<ASNTag>(b);
+    BERDecodeDate(bt, m_value, b);
+  } else
+    BERDecodeError();
+}
 
-    if (tag == (CONSTRUCTED | SEQUENCE))
-    {
-        // Authority key identifier
-        BERSequenceDecoder seq(bt);
-          if (HasOptionalAttribute(seq, CONTEXT_SPECIFIC|0))
-          {
-              BERSequenceDecoder dec(seq, CONTEXT_SPECIFIC|0);
-                m_value.New(dec.MaxRetrievable());
-                dec.Get(BytePtr(m_value), BytePtrSize(m_value));
-              dec.MessageEnd();
-          }
+void DateValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
+
+  // TODO: Implement this function
+  throw NotImplemented("DateValue::DEREncode");
+}
+
+bool DateValue::ValidateTag(byte tag) const {
+  if (tag == UTC_TIME || tag == GENERALIZED_TIME) return true;
+  return false;
+}
+
+std::ostream& DateValue::Print(std::ostream& out) const {
+  if (m_value.empty()) {
+    return out;
+  }
+
+  return out << EncodeValue();
+}
+
+std::string DateValue::EncodeValue() const {
+  if (m_value.empty()) {
+    return "";
+  }
+
+  return std::string((const char*)ConstBytePtr(m_value), BytePtrSize(m_value));
+}
+
+void ExtensionValue::BERDecode(BufferedTransformation& bt) {
+  BERSequenceDecoder seq(bt);
+  m_oid.BERDecode(seq);
+
+  m_critical = false;
+  if (HasOptionalAttribute(seq, BOOLEAN)) {
+    word32 flag;
+    BERDecodeUnsigned(seq, flag, BOOLEAN);
+    m_critical = !!flag;
+  }
+
+  BERDecodeOctetString(seq, m_value);
+
+  seq.MessageEnd();
+}
+
+void ExtensionValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
+
+  // TODO: Implement this function
+  throw NotImplemented("ExtensionValue::DEREncode");
+}
+
+bool ExtensionValue::ValidateTag(byte tag) const {
+  CRYPTOPP_UNUSED(tag);
+  return true;
+}
+
+std::ostream& ExtensionValue::Print(std::ostream& out) const {
+  if (m_value.empty()) {
+    return out;
+  }
+
+  return out << EncodeValue();
+}
+
+std::string ExtensionValue::EncodeValue() const {
+  // TODO: Implement this function
+  throw NotImplemented("ExtensionValue::EncodeValue");
+}
+
+void KeyIdentifierValue::BERDecode(BufferedTransformation& bt) {
+  byte tag;
+  if (!bt.Peek(tag) || !ValidateTag(tag)) BERDecodeError();
+
+  if (tag == CONSTRUCTED_AND_SEQUENCE) {
+    // Authority key identifier
+    BERSequenceDecoder seq(bt);
+    if (HasOptionalAttribute(seq, CONTEXT_SPECIFIC | 0)) {
+      BERSequenceDecoder dec(seq, CONTEXT_SPECIFIC | 0);
+      m_value.New(dec.MaxRetrievable());
+      dec.Get(BytePtr(m_value), BytePtrSize(m_value));
+      dec.MessageEnd();
+    }
 #if 0
           if (HasOptionalAttribute(seq, CONSTRUCTED|CONTEXT_SPECIFIC|1))
           {
@@ -554,722 +579,673 @@ void KeyIdentifierValue::BERDecode(BufferedTransformation &bt)
               dec.MessageEnd();
           }
 #endif
-          if (seq.EndReached() == false)
-          {
-              m_other.New(seq.MaxRetrievable());
-              seq.Get(BytePtr(m_other), BytePtrSize(m_other));
-          }
-        seq.MessageEnd();
-
-        m_type = KeyIdentifierValue::Hash;
-        m_oid = id_authorityKeyIdentifier;
+    if (seq.EndReached() == false) {
+      m_other.New(seq.MaxRetrievable());
+      seq.Get(BytePtr(m_other), BytePtrSize(m_other));
     }
-    else if (tag == OCTET_STRING)
-    {
-        // Subject key identifier
-        BERDecodeOctetString(bt, m_value);
+    seq.MessageEnd();
 
-        m_type = KeyIdentifierValue::Hash;
-        m_oid = id_subjectPublicKeyIdentifier;
-    }
-    else
-        BERDecodeError();
+    m_type = KeyIdentifierValue::Hash;
+    m_oid = id_authorityKeyIdentifier;
+  } else if (tag == OCTET_STRING) {
+    // Subject key identifier
+    BERDecodeOctetString(bt, m_value);
+
+    m_type = KeyIdentifierValue::Hash;
+    m_oid = id_subjectPublicKeyIdentifier;
+  } else
+    BERDecodeError();
 }
 
-void KeyIdentifierValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
+void KeyIdentifierValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
 
-    // TODO: Implement this function
-    throw NotImplemented("KeyIdentifierValue::DEREncode");
+  // TODO: Implement this function
+  throw NotImplemented("KeyIdentifierValue::DEREncode");
 }
 
-bool KeyIdentifierValue::ValidateTag(byte tag) const
-{
-    return (tag == (CONSTRUCTED | SEQUENCE)) || tag == OCTET_STRING;
+bool KeyIdentifierValue::ValidateTag(byte tag) const {
+  return (tag == CONSTRUCTED_AND_SEQUENCE) || tag == OCTET_STRING;
 }
 
-std::ostream& KeyIdentifierValue::Print(std::ostream& out) const
-{
-    if (m_value.empty())
-        { return out; }
+std::ostream& KeyIdentifierValue::Print(std::ostream& out) const {
+  if (m_value.empty()) {
+    return out;
+  }
 
-    return out << EncodeValue();
+  return out << EncodeValue();
 }
 
-std::string KeyIdentifierValue::EncodeValue() const
-{
-    std::string val;
-    if (m_type == Hash)
-    {
-        val += "hash: ";
+std::string KeyIdentifierValue::EncodeValue() const {
+  std::string val;
+  if (m_type == Hash) {
+    val += "hash: ";
 
-        HexEncoder encoder(new StringSink(val));
-        encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
-        encoder.MessageEnd();
-    }
-    else if (m_type == DnAndSn)
-    {
-        val += "name:serno: ";
+    HexEncoder encoder(new StringSink(val));
+    encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
+    encoder.MessageEnd();
+  } else if (m_type == DnAndSn) {
+    val += "name:serno: ";
 
-        // TODO: finish this once we have a cert
-        // val += "XXX, NNN";
+    // TODO: finish this once we have a cert
+    // val += "XXX, NNN";
 
-        HexEncoder encoder(new StringSink(val));
-        encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
-        encoder.MessageEnd();
-    }
+    HexEncoder encoder(new StringSink(val));
+    encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
+    encoder.MessageEnd();
+  }
 
-    return val;
+  return val;
 }
 
 IdentityValue::IdentityValue(const SecByteBlock& value, IdentityEnum src)
-    : m_value(value), m_src(src)
-{
-    if (m_src == otherName)
-        { ConvertOtherName(); }
+    : m_value(value), m_src(src) {
+  if (m_src == otherName) {
+    ConvertOtherName();
+  }
 }
 
-IdentityValue::IdentityValue(const std::string &value, IdentityEnum src)
-    : m_value(ConstBytePtr(value), BytePtrSize(value)), m_src(src)
-{
-    if (m_src == otherName)
-        { ConvertOtherName(); }
+IdentityValue::IdentityValue(const std::string& value, IdentityEnum src)
+    : m_value(ConstBytePtr(value), BytePtrSize(value)), m_src(src) {
+  if (m_src == otherName) {
+    ConvertOtherName();
+  }
 }
 
-IdentityValue::IdentityValue(const OID& oid, const SecByteBlock& value, IdentityEnum src)
-    : m_oid(oid), m_value(value), m_src(src)
-{
-    if (m_src == otherName)
-        { ConvertOtherName(); }
+IdentityValue::IdentityValue(const OID& oid, const SecByteBlock& value,
+                             IdentityEnum src)
+    : m_oid(oid), m_value(value), m_src(src) {
+  if (m_src == otherName) {
+    ConvertOtherName();
+  }
 }
 
-IdentityValue::IdentityValue(const OID& oid, const std::string &value, IdentityEnum src)
-    : m_oid(oid), m_value(ConstBytePtr(value), BytePtrSize(value)), m_src(src)
-{
-    if (m_src == otherName)
-        { ConvertOtherName(); }
+IdentityValue::IdentityValue(const OID& oid, const std::string& value,
+                             IdentityEnum src)
+    : m_oid(oid), m_value(ConstBytePtr(value), BytePtrSize(value)), m_src(src) {
+  if (m_src == otherName) {
+    ConvertOtherName();
+  }
 }
 
-std::ostream& IdentityValue::Print(std::ostream& out) const
-{
-    if (m_value.empty())
-        { return out; }
+std::ostream& IdentityValue::Print(std::ostream& out) const {
+  if (m_value.empty()) {
+    return out;
+  }
 
-    std::ostringstream oss;
-    oss << OidToNameLookup(m_oid);
-    oss << ": ";
-    oss << EncodeValue();
+  std::ostringstream oss;
+  oss << OidToNameLookup(m_oid);
+  oss << ": ";
+  oss << EncodeValue();
 
-    return out << oss.str();
+  return out << oss.str();
 }
 
-std::string IdentityValue::EncodeValue() const
-{
-    std::string val;
+std::string IdentityValue::EncodeValue() const {
+  std::string val;
 
-    switch (m_src)
-    {
-        case UniqueId:
-        case SubjectPKI:
-        {
-            HexEncoder encoder(new StringSink(val));
-            encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
-            encoder.MessageEnd();
-            break;
-        }
-        case iPAddress:
-        {
-            if (m_value.size() == 4)  // ipv4
-            {
-                std::ostringstream oss;
-                oss << (unsigned int)m_value[0] << ".";
-                oss << (unsigned int)m_value[1] << ".";
-                oss << (unsigned int)m_value[2] << ".";
-                oss << (unsigned int)m_value[3];
-                val = oss.str();
-            }
-            else  // ipv6
-            {
-                HexEncoder encoder(new StringSink(val), true, 2, ":");
-                encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
-                encoder.MessageEnd();
-            }
-            break;
-        }
-        case registeredID:
-        {
-            OID oid;
-            ArraySource store(ConstBytePtr(m_value), BytePtrSize(m_value), true);
-            oid.BERDecode(store);
-
-            std::ostringstream oss;
-            oss << oid;
-            val = oss.str();
-            break;
-        }
-        default:
-            val.resize(m_value.size());
-            std::memcpy(BytePtr(val), ConstBytePtr(m_value), BytePtrSize(val));
+  switch (m_src) {
+    case UniqueId:
+    case SubjectPKI: {
+      HexEncoder encoder(new StringSink(val));
+      encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
+      encoder.MessageEnd();
+      break;
     }
+    case iPAddress: {
+      if (m_value.size() == 4)  // ipv4
+      {
+        std::ostringstream oss;
+        oss << (unsigned int)m_value[0] << ".";
+        oss << (unsigned int)m_value[1] << ".";
+        oss << (unsigned int)m_value[2] << ".";
+        oss << (unsigned int)m_value[3];
+        val = oss.str();
+      } else  // ipv6
+      {
+        HexEncoder encoder(new StringSink(val), true, 2, ":");
+        encoder.Put(ConstBytePtr(m_value), BytePtrSize(m_value));
+        encoder.MessageEnd();
+      }
+      break;
+    }
+    case registeredID: {
+      OID oid;
+      ArraySource store(ConstBytePtr(m_value), BytePtrSize(m_value), true);
+      oid.BERDecode(store);
 
-    return val;
+      std::ostringstream oss;
+      oss << oid;
+      val = oss.str();
+      break;
+    }
+    default:
+      val.resize(m_value.size());
+      std::memcpy(BytePtr(val), ConstBytePtr(m_value), BytePtrSize(val));
+  }
+
+  return val;
 }
 
 // Microsoft PKI can include a User Principal Name in the otherName
 // https://security.stackexchange.com/q/62746/29925. For the ASN.1
 // see https://tools.ietf.org/html/rfc4556, Appendix A, Appendix C,
 // and id-ms-san-sc-logon-upn.
-void IdentityValue::ConvertOtherName()
-{
-    CRYPTOPP_ASSERT(m_src == otherName);
-    if (m_src != otherName) { return; }
+void IdentityValue::ConvertOtherName() {
+  CRYPTOPP_ASSERT(m_src == otherName);
+  if (m_src != otherName) {
+    return;
+  }
 
-    // TODO: fix this when we get a test cert
-    if (m_value[0] == OBJECT_IDENTIFIER)
+  // TODO: fix this when we get a test cert
+  if (m_value[0] == OBJECT_IDENTIFIER) {
+    SecByteBlock temp(m_value);
+    ArraySource store(ConstBytePtr(temp), BytePtrSize(temp), true);
+    OID oid;
+    oid.BERDecode(store);
+
+    const OID msUPN = id_msUserPrincipalName;
+    if (oid == msUPN)  // Turn this object into a MS UPN
     {
-        SecByteBlock temp(m_value);
-        ArraySource store(ConstBytePtr(temp), BytePtrSize(temp), true);
-        OID oid; oid.BERDecode(store);
+      try {
+        BERSequenceDecoder seq(store);
+        BERDecodeTextString(seq, m_value, UTF8_STRING);
+        seq.MessageEnd();
 
-        const OID msUPN = id_msUserPrincipalName;
-        if (oid == msUPN)  // Turn this object into a MS UPN
-        {
-            try
-            {
-                BERSequenceDecoder seq(store);
-                  BERDecodeTextString(seq, m_value, UTF8_STRING);
-                seq.MessageEnd();
-
-                m_oid = msUPN;
-                m_src = msOtherNameUPN;
-            }
-            catch (Exception& ex)
-            {
-                CRYPTOPP_UNUSED(ex);
-                CRYPTOPP_ASSERT(0);
-            }
-        }
+        m_oid = msUPN;
+        m_src = msOtherNameUPN;
+      } catch (Exception& ex) {
+        CRYPTOPP_UNUSED(ex);
+        CRYPTOPP_ASSERT(0);
+      }
     }
+  }
 }
 
 KeyUsageValue::KeyUsageValue(const OID& oid)
-    : m_oid(oid), m_usage(InvalidKeyUsage)
-{
-    m_usage = OidToKeyUsageValueLookup(oid, InvalidKeyUsage);
+    : m_oid(oid), m_usage(InvalidKeyUsage) {
+  m_usage = OidToKeyUsageValueLookup(oid, InvalidKeyUsage);
 }
 
 KeyUsageValue::KeyUsageValue(const OID& oid, KeyUsageEnum usage)
-    : m_oid(oid), m_usage(usage)
-{
+    : m_oid(oid), m_usage(usage) {}
+
+void KeyUsageValue::BERDecode(BufferedTransformation& bt) {
+  CRYPTOPP_UNUSED(bt);
+
+  // TODO: Implement this function
+  throw NotImplemented("KeyUsageValue::BERDecode");
 }
 
-void KeyUsageValue::BERDecode(BufferedTransformation &bt)
-{
-    CRYPTOPP_UNUSED(bt);
+void KeyUsageValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
 
-    // TODO: Implement this function
-    throw NotImplemented("KeyUsageValue::BERDecode");
+  // TODO: Implement this function
+  throw NotImplemented("KeyUsageValue::DEREncode");
 }
 
-void KeyUsageValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
+std::ostream& KeyUsageValue::Print(std::ostream& out) const {
+  if (m_oid.Empty()) {
+    return out;
+  }
 
-    // TODO: Implement this function
-    throw NotImplemented("KeyUsageValue::DEREncode");
+  return out << EncodeValue();
 }
 
-std::ostream& KeyUsageValue::Print(std::ostream& out) const
-{
-    if (m_oid.Empty())
-        { return out; }
+std::string KeyUsageValue::EncodeValue() const {
+  std::string val;
 
-    return out << EncodeValue();
-}
+  switch (m_usage) {
+    case digitalSignature:
+      val = "digitalSignature";
+      break;
 
-std::string KeyUsageValue::EncodeValue() const
-{
-    std::string val;
+    case nonRepudiation:
+      val = "nonRepudiation";
+      break;
 
-    switch (m_usage)
-    {
-        case digitalSignature:
-            val = "digitalSignature";
-            break;
+    case keyEncipherment:
+      val = "keyEncipherment";
+      break;
 
-        case nonRepudiation:
-            val = "nonRepudiation";
-            break;
+    case dataEncipherment:
+      val = "dataEncipherment";
+      break;
 
-        case keyEncipherment:
-            val = "keyEncipherment";
-            break;
+    case keyAgreement:
+      val = "keyAgreement";
+      break;
 
-        case dataEncipherment:
-            val = "dataEncipherment";
-            break;
+    case keyCertSign:
+      val = "keyCertSign";
+      break;
 
-        case keyAgreement:
-            val = "keyAgreement";
-            break;
+    case cRLSign:
+      val = "cRLSign";
+      break;
 
-        case keyCertSign:
-            val = "keyCertSign";
-            break;
+    case encipherOnly:
+      val = "encipherOnly";
+      break;
 
-        case cRLSign:
-            val = "cRLSign";
-            break;
+    case decipherOnly:
+      val = "decipherOnly";
+      break;
 
-        case encipherOnly:
-            val = "encipherOnly";
-            break;
+    case serverAuth:
+      val = "serverAuth";
+      break;
 
-        case decipherOnly:
-            val = "decipherOnly";
-            break;
+    case clientAuth:
+      val = "clientAuth";
+      break;
 
-        case serverAuth:
-            val = "serverAuth";
-            break;
+    case codeSigning:
+      val = "codeSigning";
+      break;
 
-        case clientAuth:
-            val = "clientAuth";
-            break;
+    case emailProtection:
+      val = "emailProtection";
+      break;
 
-        case codeSigning:
-            val = "codeSigning";
-            break;
+    case ipsecEndSystem:
+      val = "ipsecEndSystem";
+      break;
 
-        case emailProtection:
-            val = "emailProtection";
-            break;
+    case ipsecTunnel:
+      val = "ipsecTunnel";
+      break;
 
-        case ipsecEndSystem:
-            val = "ipsecEndSystem";
-            break;
+    case ipsecUser:
+      val = "ipsecUser";
+      break;
 
-        case ipsecTunnel:
-            val = "ipsecTunnel";
-            break;
+    case timeStamping:
+      val = "timeStamping";
+      break;
 
-        case ipsecUser:
-            val = "ipsecUser";
-            break;
+    case OCSPSigning:
+      val = "OCSPSigning";
+      break;
 
-        case timeStamping:
-            val = "timeStamping";
-            break;
+    case dvcs:
+      val = "dvcs";
+      break;
 
-        case OCSPSigning:
-            val = "OCSPSigning";
-            break;
+    case sbgpCertAAServerAuth:
+      val = "sbgpCertAAServerAuth";
+      break;
 
-        case dvcs:
-            val = "dvcs";
-            break;
+    case scvpResponder:
+      val = "scvpResponder";
+      break;
 
-        case sbgpCertAAServerAuth:
-            val = "sbgpCertAAServerAuth";
-            break;
+    case eapOverPPP:
+      val = "eapOverPPP";
+      break;
 
-        case scvpResponder:
-            val = "scvpResponder";
-            break;
+    case eapOverLAN:
+      val = "eapOverLAN";
+      break;
 
-        case eapOverPPP:
-            val = "eapOverPPP";
-            break;
+    case scvpServer:
+      val = "scvpServer";
+      break;
 
-        case eapOverLAN:
-            val = "eapOverLAN";
-            break;
+    case scvpClient:
+      val = "scvpClient";
+      break;
 
-        case scvpServer:
-            val = "scvpServer";
-            break;
+    case ipsecIKE:
+      val = "ipsecIKE";
+      break;
 
-        case scvpClient:
-            val = "scvpClient";
-            break;
+    case capwapAC:
+      val = "capwapAC";
+      break;
 
-        case ipsecIKE:
-            val = "ipsecIKE";
-            break;
+    case capwapWTP:
+      val = "capwapWTP";
+      break;
 
-        case capwapAC:
-            val = "capwapAC";
-            break;
+    case sipDomain:
+      val = "sipDomain";
+      break;
 
-        case capwapWTP:
-            val = "capwapWTP";
-            break;
+    case secureShellClient:
+      val = "secureShellClient";
+      break;
 
-        case sipDomain:
-            val = "sipDomain";
-            break;
+    case secureShellServer:
+      val = "secureShellServer";
+      break;
 
-        case secureShellClient:
-            val = "secureShellClient";
-            break;
+    case sendRouter:
+      val = "sendRouter";
+      break;
 
-        case secureShellServer:
-            val = "secureShellServer";
-            break;
+    case sendProxiedRouter:
+      val = "sendProxiedRouter";
+      break;
 
-        case sendRouter:
-            val = "sendRouter";
-            break;
+    case sendOwner:
+      val = "sendOwner";
+      break;
 
-        case sendProxiedRouter:
-            val = "sendProxiedRouter";
-            break;
+    case sendProxiedOwner:
+      val = "sendProxiedOwner";
+      break;
 
-        case sendOwner:
-            val = "sendOwner";
-            break;
+    case cmcCA:
+      val = "cmcCA";
+      break;
 
-        case sendProxiedOwner:
-            val = "sendProxiedOwner";
-            break;
+    case cmcRA:
+      val = "cmcRA";
+      break;
 
-        case cmcCA:
-            val = "cmcCA";
-            break;
+    case bgpsecRouter:
+      val = "bgpsecRouter";
+      break;
 
-        case cmcRA:
-            val = "cmcRA";
-            break;
+    case brandIndicatorforMessageIdentification:
+      val = "brandIndicatorforMessageIdentification";
+      break;
 
-        case bgpsecRouter:
-            val = "bgpsecRouter";
-            break;
+    default: {
+      std::ostringstream oss;
+      oss << m_oid;
+      val = oss.str();
 
-        case brandIndicatorforMessageIdentification:
-            val = "brandIndicatorforMessageIdentification";
-            break;
-
-        default:
-        {
-            std::ostringstream oss;
-            oss << m_oid;
-            val = oss.str();
-
-            break;
-        }
+      break;
     }
+  }
 
-    return val;
+  return val;
 }
 
-void BasicConstraintValue::BERDecode(BufferedTransformation &bt)
-{
-    // BasicConstraints ::= SEQUENCE {
-    //   cA                    BOOLEAN DEFAULT FALSE,
-    //   pathLenConstraint     INTEGER (0..MAX) OPTIONAL
-    // }
+void BasicConstraintValue::BERDecode(BufferedTransformation& bt) {
+  // BasicConstraints ::= SEQUENCE {
+  //   cA                    BOOLEAN DEFAULT FALSE,
+  //   pathLenConstraint     INTEGER (0..MAX) OPTIONAL
+  // }
 
-    BERSequenceDecoder seq(bt);
-      if (HasOptionalAttribute(seq, BOOLEAN))
-      {
-          word32 flag;
-          BERDecodeUnsigned(seq, flag, BOOLEAN);
-          m_ca = !!flag;
-      }
-      if (HasOptionalAttribute(seq, INTEGER))
-      {
-          word32 len;
-          BERDecodeUnsigned(seq, len, INTEGER);
-          m_pathLen = len;
-      }
-    seq.MessageEnd();
+  BERSequenceDecoder seq(bt);
+  if (HasOptionalAttribute(seq, BOOLEAN)) {
+    word32 flag;
+    BERDecodeUnsigned(seq, flag, BOOLEAN);
+    m_ca = !!flag;
+  }
+  if (HasOptionalAttribute(seq, INTEGER)) {
+    word32 len;
+    BERDecodeUnsigned(seq, len, INTEGER);
+    m_pathLen = len;
+  }
+  seq.MessageEnd();
 }
 
-void BasicConstraintValue::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
+void BasicConstraintValue::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
 
-    // TODO: Implement this function
-    throw NotImplemented("BasicConstraintValue::DEREncode");
+  // TODO: Implement this function
+  throw NotImplemented("BasicConstraintValue::DEREncode");
 }
 
 // Null values so some accessors can return something
-const SecByteBlock  X509Certificate::g_nullByteBlock;
+const SecByteBlock X509Certificate::g_nullByteBlock;
 const ExtensionValueArray X509Certificate::g_nullExtensions;
 
-void X509Certificate::Save(BufferedTransformation &bt) const
-{
-    DEREncode(bt);
+void X509Certificate::Save(BufferedTransformation& bt) const { DEREncode(bt); }
+
+void X509Certificate::Load(BufferedTransformation& bt) { BERDecode(bt); }
+
+void X509Certificate::Reset() {
+  m_origCertificate.New(0);
+  m_certSignature.New(0);
+
+  m_toBeSigned.release();
+  m_keyUsage.release();
+  m_identities.release();
+  m_extensions.release();
+  m_subjectUid.release();
+  m_issuerUid.release();
+  m_subjectPublicKey.release();
+  m_subjectKeyIdentifier.release();
+  m_authorityKeyIdentifier.release();
+
+  m_subjectName.clear();
+  m_issuerName.clear();
+
+  m_certSignatureAlgortihm = OID();
+  m_subjectSignatureAlgortihm = OID();
+  m_notBefore = m_notAfter = DateValue();
+
+  m_version = v1;
+  m_serialNumber = 0;
 }
 
-void X509Certificate::Load(BufferedTransformation &bt)
-{
-    BERDecode(bt);
+void X509Certificate::SaveCertificateBytes(BufferedTransformation& bt) {
+  m_origCertificate.resize(bt.MaxRetrievable());
+  bt.Peek(m_origCertificate, m_origCertificate.size());
 }
 
-void X509Certificate::Reset()
-{
-    m_origCertificate.New(0);
-    m_certSignature.New(0);
-
-    m_toBeSigned.release();
-    m_keyUsage.release();
-    m_identities.release();
-    m_extensions.release();
-    m_subjectUid.release();
-    m_issuerUid.release();
-    m_subjectPublicKey.release();
-    m_subjectKeyIdentifier.release();
-    m_authorityKeyIdentifier.release();
-
-    m_subjectName.clear();
-    m_issuerName.clear();
-
-    m_certSignatureAlgortihm = OID();
-    m_subjectSignatureAlgortihm = OID();
-    m_notBefore = m_notAfter = DateValue();
-
-    m_version = v1;
-    m_serialNumber = 0;
+bool X509Certificate::HasOptionalAttribute(const BufferedTransformation& bt,
+                                           byte tag) const {
+  byte b = 0;
+  if (bt.Peek(b) && b == tag) return true;
+  return false;
 }
 
-void X509Certificate::SaveCertificateBytes(BufferedTransformation &bt)
-{
-    m_origCertificate.resize(bt.MaxRetrievable());
-    bt.Peek(m_origCertificate, m_origCertificate.size());
-}
+const SecByteBlock& X509Certificate::GetToBeSigned() const {
+  if (m_toBeSigned.get() == NULLPTR) {
+    m_toBeSigned.reset(new SecByteBlock);
+    SecByteBlock& toBeSigned = *m_toBeSigned.get();
 
-bool X509Certificate::HasOptionalAttribute(const BufferedTransformation &bt, byte tag) const
-{
-    byte b = 0;
-    if (bt.Peek(b) && b == tag)
-        return true;
-    return false;
-}
+    ArraySource store(m_origCertificate, m_origCertificate.size(), true);
+    BERSequenceDecoder cert(store);
 
-const SecByteBlock& X509Certificate::GetToBeSigned() const
-{
-    if (m_toBeSigned.get() == NULLPTR)
-    {
-        m_toBeSigned.reset(new SecByteBlock);
-        SecByteBlock &toBeSigned = *m_toBeSigned.get();
+    // This gyration determines how many octets are used for
+    // tag and length under DER encoding. Then, len octets are
+    // transferred to toBeSigned. If tbsCertificate is not DER
+    // encoded, then this could break. Note the RFC requires
+    // DER encoding, so it is not a problem in practice.
+    size_t len = BERDecodePeekLength(cert);
+    len += 1 /*SEQ*/ + DERLengthEncode(TheBitBucket(), len);
 
-        ArraySource store(m_origCertificate, m_origCertificate.size(), true);
-        BERSequenceDecoder cert(store);
+    toBeSigned.New(len);
+    cert.Get(BytePtr(toBeSigned), BytePtrSize(toBeSigned));
+    cert.SkipAll();  // Remaining octets are not needed.
+    cert.MessageEnd();
+  }
 
-          // This gyration determines how many octets are used for
-          // tag and length under DER encoding. Then, len octets are
-          // transferred to toBeSigned. If tbsCertificate is not DER
-          // encoded, then this could break. Note the RFC requires
-          // DER encoding, so it is not a problem in practice.
-          size_t len = BERDecodePeekLength(cert);
-          len += 1 /*SEQ*/ + DERLengthEncode(TheBitBucket(), len);
-
-          toBeSigned.New(len);
-          cert.Get(BytePtr(toBeSigned), BytePtrSize(toBeSigned));
-          cert.SkipAll();  // Remaining octets are not needed.
-        cert.MessageEnd();
-    }
-
-    return *m_toBeSigned.get();
+  return *m_toBeSigned.get();
 }
 
 // RFC 5280, Appendix A, pp. 112-116
-void X509Certificate::BERDecode(BufferedTransformation &bt)
-{
-    // Clear old certificate data
-    Reset();
+void X509Certificate::BERDecode(BufferedTransformation& bt) {
+  // Clear old certificate data
+  Reset();
 
-    // Stash a copy of the certificate.
-    SaveCertificateBytes(bt);
+  // Stash a copy of the certificate.
+  SaveCertificateBytes(bt);
 
-    BERSequenceDecoder certificate(bt);
+  BERSequenceDecoder certificate(bt);
 
-      BERSequenceDecoder tbsCertificate(certificate);
+  BERSequenceDecoder tbsCertificate(certificate);
 
-        if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC|CONSTRUCTED|0))
-            BERDecodeVersion(tbsCertificate, m_version);
-        else
-            m_version = v1;  // Default per RFC
+  if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC | CONSTRUCTED | 0))
+    BERDecodeVersion(tbsCertificate, m_version);
+  else
+    m_version = v1;  // Default per RFC
 
-        BERDecodeSerialNumber(tbsCertificate, m_serialNumber);
+  BERDecodeSerialNumber(tbsCertificate, m_serialNumber);
 
-        BERDecodeSignatureAlgorithm(tbsCertificate, m_subjectSignatureAlgortihm);
+  BERDecodeSignatureAlgorithm(tbsCertificate, m_subjectSignatureAlgortihm);
 
-        BERDecodeDistinguishedName(tbsCertificate, m_issuerName);
+  BERDecodeDistinguishedName(tbsCertificate, m_issuerName);
 
-        BERDecodeValidity(tbsCertificate, m_notBefore, m_notAfter);
+  BERDecodeValidity(tbsCertificate, m_notBefore, m_notAfter);
 
-        BERDecodeDistinguishedName(tbsCertificate, m_subjectName);
+  BERDecodeDistinguishedName(tbsCertificate, m_subjectName);
 
-        BERDecodeSubjectPublicKeyInfo(tbsCertificate, m_subjectPublicKey);
+  BERDecodeSubjectPublicKeyInfo(tbsCertificate, m_subjectPublicKey);
 
-        if (m_version < v2 || tbsCertificate.EndReached())
-            goto TBS_Done;
+  if (m_version < v2 || tbsCertificate.EndReached()) goto TBS_Done;
 
-        // UniqueIdentifiers are v2
-        if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC|CONSTRUCTED|1))
-            BERDecodeIssuerUniqueId(tbsCertificate);
+  // UniqueIdentifiers are v2
+  if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC | CONSTRUCTED | 1))
+    BERDecodeIssuerUniqueId(tbsCertificate);
 
-        if (tbsCertificate.EndReached())
-            goto TBS_Done;
+  if (tbsCertificate.EndReached()) goto TBS_Done;
 
-        if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC|CONSTRUCTED|2))
-            BERDecodeSubjectUniqueId(tbsCertificate);
+  if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC | CONSTRUCTED | 2))
+    BERDecodeSubjectUniqueId(tbsCertificate);
 
-        if (m_version < v3 || tbsCertificate.EndReached())
-            goto TBS_Done;
+  if (m_version < v3 || tbsCertificate.EndReached()) goto TBS_Done;
 
-        // Extensions are v3
-        if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC|CONSTRUCTED|3))
-            BERDecodeExtensions(tbsCertificate);
+  // Extensions are v3
+  if (HasOptionalAttribute(tbsCertificate, CONTEXT_SPECIFIC | CONSTRUCTED | 3))
+    BERDecodeExtensions(tbsCertificate);
 
-    TBS_Done:
+TBS_Done:
 
-      tbsCertificate.MessageEnd();
+  tbsCertificate.MessageEnd();
 
-      BERDecodeSignatureAlgorithm(certificate, m_certSignatureAlgortihm);
+  BERDecodeSignatureAlgorithm(certificate, m_certSignatureAlgortihm);
 
-      BERDecodeSignature(certificate, m_certSignature);
+  BERDecodeSignature(certificate, m_certSignature);
 
-    certificate.MessageEnd();
+  certificate.MessageEnd();
 }
 
-void X509Certificate::DEREncode(BufferedTransformation &bt) const
-{
-    CRYPTOPP_UNUSED(bt);
+void X509Certificate::DEREncode(BufferedTransformation& bt) const {
+  CRYPTOPP_UNUSED(bt);
 
-    // TODO: Implement this function
-    throw NotImplemented("X509Certificate::DEREncode");
+  // TODO: Implement this function
+  throw NotImplemented("X509Certificate::DEREncode");
 }
 
-void X509Certificate::BERDecodeSignature(BufferedTransformation &bt, SecByteBlock &signature)
-{
+void X509Certificate::BERDecodeSignature(BufferedTransformation& bt,
+                                         SecByteBlock& signature) {
+  word32 unused;
+  BERDecodeBitString(bt, signature, unused);
+  CRYPTOPP_ASSERT(unused == 0);
+
+  // For ECDSA, convert from DER to P1363 so the signature is ready to use.
+  const OID& algorithm = GetCertificateSignatureAlgorithm();
+  if (IsECDSAAlgorithm(algorithm)) {
+    const X509PublicKey& publicKey = GetSubjectPublicKey();
+    member_ptr<PK_Verifier> verifier(
+        GetPK_VerifierObject(algorithm, publicKey));
+    CRYPTOPP_ASSERT(verifier.get());
+
+    size_t size = verifier->SignatureLength();
+    SecByteBlock p1363Signature(size);
+
+    // https://www.cryptopp.com/wiki/DSAConvertSignatureFormat
+    size = DSAConvertSignatureFormat(p1363Signature, p1363Signature.size(),
+                                     DSA_P1363, signature, signature.size(),
+                                     DSA_DER);
+    p1363Signature.resize(size);
+
+    std::swap(signature, p1363Signature);
+  }
+}
+
+void X509Certificate::BERDecodeIssuerUniqueId(BufferedTransformation& bt) {
+  CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 1));
+
+  m_issuerUid.reset(new SecByteBlock);
+  SecByteBlock temp;
+
+  BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 1);
+  if (!seq.EndReached())  // Guard for a1:00
+  {
     word32 unused;
-    BERDecodeBitString(bt, signature, unused);
+    BERDecodeBitString(bt, temp, unused);
     CRYPTOPP_ASSERT(unused == 0);
+  }
+  seq.MessageEnd();
 
-    // For ECDSA, convert from DER to P1363 so the signature is ready to use.
-    const OID &algorithm = GetCertificateSignatureAlgorithm();
-    if (IsECDSAAlgorithm(algorithm))
-    {
-        const X509PublicKey &publicKey = GetSubjectPublicKey();
-        member_ptr<PK_Verifier> verifier(GetPK_VerifierObject(algorithm, publicKey));
-        CRYPTOPP_ASSERT(verifier.get());
+  std::swap(temp, *m_issuerUid.get());
+}
 
-        size_t size = verifier->SignatureLength();
-        SecByteBlock p1363Signature(size);
+void X509Certificate::BERDecodeSubjectUniqueId(BufferedTransformation& bt) {
+  CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 2));
 
-        // https://www.cryptopp.com/wiki/DSAConvertSignatureFormat
-        size = DSAConvertSignatureFormat(
-                    p1363Signature, p1363Signature.size(), DSA_P1363,
-                    signature, signature.size(), DSA_DER);
-        p1363Signature.resize(size);
+  m_subjectUid.reset(new SecByteBlock);
+  SecByteBlock temp;
 
-        std::swap(signature, p1363Signature);
+  BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 2);
+  if (!seq.EndReached())  // Guard for a2:00
+  {
+    word32 unused;
+    BERDecodeBitString(bt, temp, unused);
+    CRYPTOPP_ASSERT(unused == 0);
+  }
+  seq.MessageEnd();
+
+  std::swap(temp, *m_subjectUid.get());
+}
+
+void X509Certificate::BERDecodeExtensions(BufferedTransformation& bt) {
+  CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 3));
+
+  m_extensions.reset(new ExtensionValueArray);
+  ExtensionValueArray temp;
+
+  BERGeneralDecoder extensions(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 3);
+  if (!extensions.EndReached())  // Guard for a3:00
+  {
+    BERSequenceDecoder seq(extensions);
+    while (!seq.EndReached()) {
+      ExtensionValue value;
+      value.BERDecode(seq);
+      temp.push_back(value);
     }
-}
-
-void X509Certificate::BERDecodeIssuerUniqueId(BufferedTransformation &bt)
-{
-    CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC|CONSTRUCTED|1));
-
-    m_issuerUid.reset(new SecByteBlock);
-    SecByteBlock temp;
-
-    BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC|CONSTRUCTED|1);
-      if (! seq.EndReached())  // Guard for a1:00
-      {
-          word32 unused;
-          BERDecodeBitString(bt, temp, unused);
-          CRYPTOPP_ASSERT(unused == 0);
-      }
     seq.MessageEnd();
+  }
 
-    std::swap(temp, *m_issuerUid.get());
+  extensions.MessageEnd();
+
+  std::swap(temp, *m_extensions.get());
 }
 
-void X509Certificate::BERDecodeSubjectUniqueId(BufferedTransformation &bt)
-{
-    CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC|CONSTRUCTED|2));
+void X509Certificate::BERDecodeSubjectPublicKeyInfo(
+    BufferedTransformation& bt, member_ptr<X509PublicKey>& publicKey) {
+  OID algorithm;  // Public key algorithm
+  OID field;      // Field for elliptic curves
 
-    m_subjectUid.reset(new SecByteBlock);
-    SecByteBlock temp;
+  // See the comments for BERDecodeSubjectPublicKeyInfo for
+  // why we are not using m_subjectSignatureAlgortihm.
+  GetSubjectPublicKeyInfoOids(bt, algorithm, field);
 
-    BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC|CONSTRUCTED|2);
-      if (! seq.EndReached())  // Guard for a2:00
-      {
-          word32 unused;
-          BERDecodeBitString(bt, temp, unused);
-          CRYPTOPP_ASSERT(unused == 0);
-      }
-    seq.MessageEnd();
-
-    std::swap(temp, *m_subjectUid.get());
-}
-
-void X509Certificate::BERDecodeExtensions(BufferedTransformation &bt)
-{
-    CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC|CONSTRUCTED|3));
-
-    m_extensions.reset(new ExtensionValueArray);
-    ExtensionValueArray temp;
-
-    BERGeneralDecoder extensions(bt, CONTEXT_SPECIFIC|CONSTRUCTED|3);
-      if (! extensions.EndReached())  // Guard for a3:00
-      {
-          BERSequenceDecoder seq(extensions);
-            while (! seq.EndReached())
-            {
-                ExtensionValue value;
-                value.BERDecode(seq);
-                temp.push_back(value);
-            }
-          seq.MessageEnd();
-      }
-
-    extensions.MessageEnd();
-
-    std::swap(temp, *m_extensions.get());
-}
-
-void X509Certificate::BERDecodeSubjectPublicKeyInfo(BufferedTransformation &bt, member_ptr<X509PublicKey>& publicKey)
-{
-    OID algorithm;  // Public key algorithm
-    OID field;      // Field for elliptic curves
-
-    // See the comments for BERDecodeSubjectPublicKeyInfo for
-    // why we are not using m_subjectSignatureAlgortihm.
-    GetSubjectPublicKeyInfoOids(bt, algorithm, field);
-
-    if (IsRSAAlgorithm(algorithm))
-        publicKey.reset(new RSA::PublicKey);
-    else if (IsDSAAlgorithm(algorithm))
-        publicKey.reset(new DSA::PublicKey);
-    else if (IsEd25519Algorithm(algorithm))
-        publicKey.reset(new ed25519PublicKey);
-    else if (IsECPrimeFieldAlgorithm(algorithm, field))
-        publicKey.reset(new DL_PublicKey_EC<ECP>);
-    else if (IsECBinaryFieldAlgorithm(algorithm, field))
-        publicKey.reset(new DL_PublicKey_EC<EC2N>);
-    else
-    {
-        std::ostringstream oss;
-        oss << "X509Certificate::BERDecodeSubjectPublicKeyInfo: ";
-        if (field.Empty() == false) {
-            oss << "Field " << field << " is not supported";
-        } else {
-            oss << "Algorithm " << algorithm << " is not supported";
-        }
-        throw NotImplemented(oss.str());
+  if (IsRSAAlgorithm(algorithm))
+    publicKey.reset(new RSA::PublicKey);
+  else if (IsDSAAlgorithm(algorithm))
+    publicKey.reset(new DSA::PublicKey);
+  else if (IsEd25519Algorithm(algorithm))
+    publicKey.reset(new ed25519PublicKey);
+  else if (IsECPrimeFieldAlgorithm(algorithm, field))
+    publicKey.reset(new DL_PublicKey_EC<ECP>);
+  else if (IsECBinaryFieldAlgorithm(algorithm, field))
+    publicKey.reset(new DL_PublicKey_EC<EC2N>);
+  else {
+    std::ostringstream oss;
+    oss << "X509Certificate::BERDecodeSubjectPublicKeyInfo: ";
+    if (field.Empty() == false) {
+      oss << "Field " << field << " is not supported";
+    } else {
+      oss << "Algorithm " << algorithm << " is not supported";
     }
+    throw NotImplemented(oss.str());
+  }
 
-    publicKey->Load(bt);
+  publicKey->Load(bt);
 
 #if defined(PEM_KEY_OR_PARAMETER_VALIDATION) && !defined(NO_OS_DEPENDENCE)
-    AutoSeededRandomPool prng;
-    publicKey->Validate(prng, 3);
+  AutoSeededRandomPool prng;
+  publicKey->Validate(prng, 3);
 #endif
 }
 
@@ -1279,740 +1255,681 @@ void X509Certificate::BERDecodeSubjectPublicKeyInfo(BufferedTransformation &bt, 
 // (prime vs. binary). We need a field to instantiate a key. For example,
 // subjectPublicKeyAlgorithm==ecdsa_with_sha384() does not contain enough
 // information to determine PublicKey_EC<ECP> or PublicKey_EC<EC2N>.
-void X509Certificate::GetSubjectPublicKeyInfoOids(const BufferedTransformation &bt, OID& algorithm, OID& field) const
-{
-    try
-    {
-        // We need to read enough of the stream to determine the OIDs.
-        ByteQueue temp;
-        bt.CopyTo(temp, BERDecodePeekLength(bt));
+void X509Certificate::GetSubjectPublicKeyInfoOids(
+    const BufferedTransformation& bt, OID& algorithm, OID& field) const {
+  try {
+    // We need to read enough of the stream to determine the OIDs.
+    ByteQueue temp;
+    bt.CopyTo(temp, BERDecodePeekLength(bt));
 
-        BERSequenceDecoder seq1(temp);
-          BERSequenceDecoder seq2(seq1);
-            algorithm.BERDecode(seq2);
-            // EC Public Keys specify a field, also
-            if (algorithm == ASN1::id_ecPublicKey())
-                { field.BERDecode(seq2); }
-            seq2.SkipAll();
-          seq2.MessageEnd();
-          seq1.SkipAll();
-        seq1.MessageEnd();
+    BERSequenceDecoder seq1(temp);
+    BERSequenceDecoder seq2(seq1);
+    algorithm.BERDecode(seq2);
+    // EC Public Keys specify a field, also
+    if (algorithm == ASN1::id_ecPublicKey()) {
+      field.BERDecode(seq2);
     }
-    catch (const BERDecodeErr&)
-    {
-    }
+    seq2.SkipAll();
+    seq2.MessageEnd();
+    seq1.SkipAll();
+    seq1.MessageEnd();
+  } catch (const BERDecodeErr&) {
+  }
 }
 
-void X509Certificate::BERDecodeValidity(BufferedTransformation &bt, DateValue &notBefore, DateValue &notAfter)
-{
-    BERSequenceDecoder validitiy(bt);
-      notBefore.BERDecode(validitiy);
-      notAfter.BERDecode(validitiy);
-    validitiy.MessageEnd();
+void X509Certificate::BERDecodeValidity(BufferedTransformation& bt,
+                                        DateValue& notBefore,
+                                        DateValue& notAfter) {
+  BERSequenceDecoder validitiy(bt);
+  notBefore.BERDecode(validitiy);
+  notAfter.BERDecode(validitiy);
+  validitiy.MessageEnd();
 }
 
-void X509Certificate::BERDecodeDistinguishedName(BufferedTransformation &bt, RdnValueArray &rdnArray)
-{
-    // The name is a RDNSequence. It looks like:
-    //   SEQUENCE {
-    //     SET {
-    //       SEQUENCE {
-    //         OBJECT IDENTIFIER countryName (2 5 4 6)
-    //         PrintableString 'US'
-    //       }
-    //     }
-    //     SET {
-    //       SEQUENCE {
-    //         OBJECT IDENTIFIER stateOrProvinceName (2 5 4 8)
-    //         UTF8String 'NY'
-    //       }
-    //     }
-    //     ...
-    //   }
+void X509Certificate::BERDecodeDistinguishedName(BufferedTransformation& bt,
+                                                 RdnValueArray& rdnArray) {
+  // The name is a RDNSequence. It looks like:
+  //   SEQUENCE {
+  //     SET {
+  //       SEQUENCE {
+  //         OBJECT IDENTIFIER countryName (2 5 4 6)
+  //         PrintableString 'US'
+  //       }
+  //     }
+  //     SET {
+  //       SEQUENCE {
+  //         OBJECT IDENTIFIER stateOrProvinceName (2 5 4 8)
+  //         UTF8String 'NY'
+  //       }
+  //     }
+  //     ...
+  //   }
 
-    RdnValueArray temp;
-    BERSequenceDecoder rdnSequence(bt);
+  RdnValueArray temp;
+  BERSequenceDecoder rdnSequence(bt);
 
-      while (! rdnSequence.EndReached())
-      {
-          BERSetDecoder set(rdnSequence);
-            RdnValue value;
-            value.BERDecode(set);
-            temp.push_back(value);
-          set.MessageEnd();
-      }
+  while (!rdnSequence.EndReached()) {
+    BERSetDecoder set(rdnSequence);
+    RdnValue value;
+    value.BERDecode(set);
+    temp.push_back(value);
+    set.MessageEnd();
+  }
 
-    rdnSequence.MessageEnd();
+  rdnSequence.MessageEnd();
 
-    std::swap(temp, rdnArray);
+  std::swap(temp, rdnArray);
 }
 
-void X509Certificate::BERDecodeSignatureAlgorithm(BufferedTransformation &bt, OID &algorithm)
-{
-    BERSequenceDecoder seq(bt);
-      algorithm.BERDecode(seq);
-      bool parametersPresent = seq.EndReached() ? false : BERDecodeAlgorithmParameters(seq);
-      // TODO: Figure out what to do here???
-      CRYPTOPP_ASSERT(parametersPresent == false);
-      CRYPTOPP_UNUSED(parametersPresent);
-    seq.MessageEnd();
+void X509Certificate::BERDecodeSignatureAlgorithm(BufferedTransformation& bt,
+                                                  OID& algorithm) {
+  BERSequenceDecoder seq(bt);
+  algorithm.BERDecode(seq);
+  bool parametersPresent =
+      seq.EndReached() ? false : BERDecodeAlgorithmParameters(seq);
+  // TODO: Figure out what to do here???
+  CRYPTOPP_ASSERT(parametersPresent == false);
+  CRYPTOPP_UNUSED(parametersPresent);
+  seq.MessageEnd();
 }
 
-void X509Certificate::BERDecodeVersion(BufferedTransformation &bt, Version &version)
-{
-    CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC|CONSTRUCTED|0));
+void X509Certificate::BERDecodeVersion(BufferedTransformation& bt,
+                                       Version& version) {
+  CRYPTOPP_ASSERT(HasOptionalAttribute(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 0));
 
-    word32 value = v1;  // Default per RFC
-    BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC|CONSTRUCTED|0);
-      if (! seq.EndReached())  // Guard for a0:00
-      {
-          BERDecodeUnsigned<word32>(seq, value, INTEGER, 0, 2);  // check version
-      }
-    seq.MessageEnd();
+  word32 value = v1;  // Default per RFC
+  BERGeneralDecoder seq(bt, CONTEXT_SPECIFIC | CONSTRUCTED | 0);
+  if (!seq.EndReached())  // Guard for a0:00
+  {
+    BERDecodeUnsigned<word32>(seq, value, INTEGER, 0, 2);  // check version
+  }
+  seq.MessageEnd();
 
-    version = static_cast<Version>(value);
+  version = static_cast<Version>(value);
 }
 
-void X509Certificate::BERDecodeSerialNumber(BufferedTransformation &bt, Integer &serno)
-{
-    serno.BERDecode(bt);
+void X509Certificate::BERDecodeSerialNumber(BufferedTransformation& bt,
+                                            Integer& serno) {
+  serno.BERDecode(bt);
 }
 
-bool X509Certificate::Validate(RandomNumberGenerator &rng, unsigned int level) const
-{
-    // TODO: add more tests
-    bool pass = true, valid;
+bool X509Certificate::Validate(RandomNumberGenerator& rng,
+                               unsigned int level) const {
+  // TODO: add more tests
+  bool pass = true, valid;
 
-    valid = m_subjectPublicKey->Validate(rng, level);
+  valid = m_subjectPublicKey->Validate(rng, level);
+  pass = valid && pass;
+  CRYPTOPP_ASSERT(valid);
+
+  if (IsSelfSigned() && level >= 1) {
+    const X509PublicKey& publicKey = GetSubjectPublicKey();
+    valid = ValidateSignature(rng, publicKey);
     pass = valid && pass;
     CRYPTOPP_ASSERT(valid);
+  }
 
-    if (IsSelfSigned() && level >= 1)
-    {
-        const X509PublicKey &publicKey = GetSubjectPublicKey();
-        valid = ValidateSignature(rng, publicKey);
-        pass = valid && pass;
-        CRYPTOPP_ASSERT(valid);
-    }
-
-    return pass;
+  return pass;
 }
 
-bool X509Certificate::ValidateSignature (RandomNumberGenerator &rng, const X509PublicKey &key) const
-{
-    CRYPTOPP_UNUSED(rng);
+bool X509Certificate::ValidateSignature(RandomNumberGenerator& rng,
+                                        const X509PublicKey& key) const {
+  CRYPTOPP_UNUSED(rng);
 
-    const OID &algorithm = GetCertificateSignatureAlgorithm();
-    member_ptr<PK_Verifier> verifier(GetPK_VerifierObject(algorithm, key));
-    CRYPTOPP_ASSERT(verifier.get());
+  const OID& algorithm = GetCertificateSignatureAlgorithm();
+  member_ptr<PK_Verifier> verifier(GetPK_VerifierObject(algorithm, key));
+  CRYPTOPP_ASSERT(verifier.get());
 
-    const SecByteBlock &signature = GetCertificateSignature();
-    const SecByteBlock &toBeSigned = GetToBeSigned();
+  const SecByteBlock& signature = GetCertificateSignature();
+  const SecByteBlock& toBeSigned = GetToBeSigned();
 
-    bool valid = verifier->VerifyMessage(toBeSigned, toBeSigned.size(), signature, signature.size());
-    CRYPTOPP_ASSERT(valid);
+  bool valid = verifier->VerifyMessage(toBeSigned, toBeSigned.size(), signature,
+                                       signature.size());
+  CRYPTOPP_ASSERT(valid);
 
-    return valid;
+  return valid;
 }
 
 // Get the verifier object for an algorithm and key.
-PK_Verifier* X509Certificate::GetPK_VerifierObject(const OID &algorithm, const X509PublicKey &key) const
-{
-    member_ptr<PK_Verifier> verifier;
+PK_Verifier* X509Certificate::GetPK_VerifierObject(
+    const OID& algorithm, const X509PublicKey& key) const {
+  member_ptr<PK_Verifier> verifier;
 
-    if (algorithm == id_sha1WithRSASignature)
-    {
-        verifier.reset(new RSASS<PKCS1v15, SHA1>::Verifier(key));
-    }
-    else if (algorithm == id_sha256WithRSAEncryption)
-    {
-        verifier.reset(new RSASS<PKCS1v15, SHA256>::Verifier(key));
-    }
-    else if (algorithm == id_sha384WithRSAEncryption)
-    {
-        verifier.reset(new RSASS<PKCS1v15, SHA384>::Verifier(key));
-    }
-    else if (algorithm == id_sha512WithRSAEncryption)
-    {
-        verifier.reset(new RSASS<PKCS1v15, SHA512>::Verifier(key));
-    }
-    // This OID only specifies RSA/PSS. The ASN.1 needs to be parsed
-    // further to determine the hash and other parameters. However,
-    // SHA-1 was deprecated by the CA/B Baseline Requirements in 2016.
-    // We should only encounter SHA-256 nowadays.
-    else if (algorithm == OID(1)+2+840+113549+1+1+10)
-    {
-        verifier.reset(new RSASS<PSS, SHA256>::Verifier(key));
-    }
-    else if (algorithm == id_ecdsaWithSHA1)
-    {
-        verifier.reset(new ECDSA<ECP, SHA1>::Verifier(key));
-    }
-    else if (algorithm == id_ecdsaWithSHA256)
-    {
-        verifier.reset(new ECDSA<ECP, SHA256>::Verifier(key));
-    }
-    else if (algorithm == id_ecdsaWithSHA384)
-    {
-        verifier.reset(new ECDSA<ECP, SHA384>::Verifier(key));
-    }
-    else if (algorithm == id_ecdsaWithSHA512)
-    {
-        verifier.reset(new ECDSA<ECP, SHA512>::Verifier(key));
-    }
-    else if (algorithm == ASN1::Ed25519())
-    {
-        verifier.reset(new ed25519::Verifier(key));
-    }
-    // PKIX uses OID 1.3.6.1.4.1.11591.15.1 and calls it curve25519.
-    // See https://datatracker.ietf.org/doc/html/draft-josefsson-pkix-newcurves
-    // OpenPGP and GNU use the OID to indicate Ed25519 signing.
-    // See https://www.gnupg.org/oids.html,
-    // https://www.gnu.org/prep/standards/html_node/OID-Allocations.html,
-    // https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-rfc4880bis
-    else if (algorithm == OID(1)+3+6+1+4+1+11591+15+1)
-    {
-        verifier.reset(new ed25519::Verifier(key));
-    }
-    else
-    {
-        CRYPTOPP_ASSERT(0);
-    }
+  if (algorithm == id_sha1WithRSASignature) {
+    verifier.reset(new RSASS<PKCS1v15, SHA1>::Verifier(key));
+  } else if (algorithm == id_sha256WithRSAEncryption) {
+    verifier.reset(new RSASS<PKCS1v15, SHA256>::Verifier(key));
+  } else if (algorithm == id_sha384WithRSAEncryption) {
+    verifier.reset(new RSASS<PKCS1v15, SHA384>::Verifier(key));
+  } else if (algorithm == id_sha512WithRSAEncryption) {
+    verifier.reset(new RSASS<PKCS1v15, SHA512>::Verifier(key));
+  }
+  // This OID only specifies RSA/PSS. The ASN.1 needs to be parsed
+  // further to determine the hash and other parameters. However,
+  // SHA-1 was deprecated by the CA/B Baseline Requirements in 2016.
+  // We should only encounter SHA-256 nowadays.
+  else if (algorithm == OID(1) + 2 + 840 + 113549 + 1 + 1 + 10) {
+    verifier.reset(new RSASS<PSS, SHA256>::Verifier(key));
+  } else if (algorithm == id_ecdsaWithSHA1) {
+    verifier.reset(new ECDSA<ECP, SHA1>::Verifier(key));
+  } else if (algorithm == id_ecdsaWithSHA256) {
+    verifier.reset(new ECDSA<ECP, SHA256>::Verifier(key));
+  } else if (algorithm == id_ecdsaWithSHA384) {
+    verifier.reset(new ECDSA<ECP, SHA384>::Verifier(key));
+  } else if (algorithm == id_ecdsaWithSHA512) {
+    verifier.reset(new ECDSA<ECP, SHA512>::Verifier(key));
+  } else if (algorithm == ASN1::Ed25519()) {
+    verifier.reset(new ed25519::Verifier(key));
+  }
+  // PKIX uses OID 1.3.6.1.4.1.11591.15.1 and calls it curve25519.
+  // See https://datatracker.ietf.org/doc/html/draft-josefsson-pkix-newcurves
+  // OpenPGP and GNU use the OID to indicate Ed25519 signing.
+  // See https://www.gnupg.org/oids.html,
+  // https://www.gnu.org/prep/standards/html_node/OID-Allocations.html,
+  // https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-rfc4880bis
+  else if (algorithm == OID(1) + 3 + 6 + 1 + 4 + 1 + 11591 + 15 + 1) {
+    verifier.reset(new ed25519::Verifier(key));
+  } else {
+    CRYPTOPP_ASSERT(0);
+  }
 
-    return verifier.release();
+  return verifier.release();
 }
 
-void X509Certificate::AssignFrom(const NameValuePairs &source)
-{
-    ConstByteArrayParameter val;
-    if (source.GetValue("Certificate", val))
-    {
-        ArraySource certificate(val.begin(), val.size(), true);
-        Load(certificate);
-    }
+void X509Certificate::AssignFrom(const NameValuePairs& source) {
+  ConstByteArrayParameter val;
+  if (source.GetValue("Certificate", val)) {
+    ArraySource certificate(val.begin(), val.size(), true);
+    Load(certificate);
+  }
 }
 
-bool X509Certificate::GetVoidValue(const char *name, const std::type_info &valueType, void *pValue) const
-{
-    if (std::strcmp(name, "Certificate") == 0)
-    {
-        this->ThrowIfTypeMismatch(name, typeid(ConstByteArrayParameter), valueType);
-        reinterpret_cast<ConstByteArrayParameter*>(pValue)->Assign(m_origCertificate, m_origCertificate.size(), false);
-        return true;
-    }
+bool X509Certificate::GetVoidValue(const char* name,
+                                   const std::type_info& valueType,
+                                   void* pValue) const {
+  if (std::strcmp(name, "Certificate") == 0) {
+    this->ThrowIfTypeMismatch(name, typeid(ConstByteArrayParameter), valueType);
+    reinterpret_cast<ConstByteArrayParameter*>(pValue)->Assign(
+        m_origCertificate, m_origCertificate.size(), false);
+    return true;
+  }
+  return false;
+}
+
+bool X509Certificate::FindExtension(
+    const OID& oid, ExtensionValueArray::const_iterator& loc) const {
+  if (HasExtensions() == false) {
+    // Set loc to something
+    loc = g_nullExtensions.end();
     return false;
+  }
+
+  ExtensionValueArray::const_iterator first = m_extensions.get()->begin();
+  ExtensionValueArray::const_iterator last = m_extensions.get()->end();
+
+  while (first != last) {
+    if (first->m_oid == oid) {
+      loc = first;
+      return true;
+    }
+    ++first;
+  }
+  loc = last;
+  return false;
 }
 
-bool X509Certificate::FindExtension(const OID& oid, ExtensionValueArray::const_iterator& loc) const
-{
-    if (HasExtensions() == false)
-    {
-        // Set loc to something
-        loc = g_nullExtensions.end();
-        return false;
-    }
+bool X509Certificate::HasIssuerUniqueId() const {
+  return m_issuerUid.get() != NULLPTR;
+}
 
-    ExtensionValueArray::const_iterator first = m_extensions.get()->begin();
-    ExtensionValueArray::const_iterator last = m_extensions.get()->end();
+bool X509Certificate::HasSubjectUniqueId() const {
+  return m_subjectUid.get() != NULLPTR;
+}
 
-    while (first != last)
-    {
-        if (first->m_oid == oid) {
-            loc = first;
-            return true;
-        }
-        ++first;
-    }
-    loc = last;
+bool X509Certificate::HasExtensions() const {
+  return m_extensions.get() != NULLPTR;
+}
+
+bool X509Certificate::HasAuthorityKeyIdentifier() const {
+  if (HasExtensions() == false) {
     return false;
+  }
+
+  ExtensionValueArray::const_iterator unused;
+  return FindExtension(id_authorityKeyIdentifier, unused);
 }
 
-bool X509Certificate::HasIssuerUniqueId() const
-{
-    return m_issuerUid.get() != NULLPTR;
+bool X509Certificate::HasSubjectKeyIdentifier() const {
+  if (HasExtensions() == false) {
+    return false;
+  }
+
+  ExtensionValueArray::const_iterator unused;
+  return FindExtension(id_subjectPublicKeyIdentifier, unused);
 }
 
-bool X509Certificate::HasSubjectUniqueId() const
-{
-    return m_subjectUid.get() != NULLPTR;
+bool X509Certificate::IsCertificateAuthority() const {
+  // BasicConstraints ::= SEQUENCE {
+  //   cA                    BOOLEAN DEFAULT FALSE,
+  //   pathLenConstraint     INTEGER (0..MAX) OPTIONAL
+  // }
+
+  ExtensionValueArray::const_iterator loc;
+  if (FindExtension(id_basicConstraints, loc)) {
+    const ExtensionValue& ext = *loc;
+    BasicConstraintValue basicConstraints(ext.m_critical);
+
+    ArraySource store(ext.m_value, ext.m_value.size(), true);
+    basicConstraints.BERDecode(store);
+
+    return basicConstraints.m_ca;
+  }
+
+  return false;
 }
 
-bool X509Certificate::HasExtensions() const
-{
-    return m_extensions.get() != NULLPTR;
+bool X509Certificate::IsSelfSigned() const {
+  // IssuerUID and SubjectUID are optional
+  if (HasIssuerUniqueId() && HasSubjectUniqueId() &&
+      GetIssuerUniqueId() == GetSubjectUniqueId())
+    return true;
+
+  // AKI and SPKI are optional
+  if (HasAuthorityKeyIdentifier() && HasSubjectKeyIdentifier() &&
+      GetAuthorityKeyIdentifier() == GetSubjectKeyIdentifier())
+    return true;
+
+  // Distinguished Names
+  bool same = false;
+  if (m_issuerName.size() == m_subjectName.size()) {
+    RdnValueArray::const_iterator a = m_issuerName.begin();
+    RdnValueArray::const_iterator b = m_subjectName.begin();
+    RdnValueArray::const_iterator c = m_issuerName.end();
+
+    same = true;
+    while (a != c) {
+      same = (a->m_value == b->m_value) && same;
+      ++a;
+      ++b;
+    }
+  }
+
+  return same;
 }
 
-bool X509Certificate::HasAuthorityKeyIdentifier() const
-{
-    if (HasExtensions() == false)
-        { return false; }
+const KeyIdentifierValue& X509Certificate::GetAuthorityKeyIdentifier() const {
+  // OCTET STRING, encapsulates {
+  //   SEQUENCE {
+  //     [0]
+  //       AE 22 75 36 0B F0 D2 37 CB D2 AB 5B 47 B7 9E B0
+  //       ED 15 E5 9A
+  //   }
+  // }
 
-    ExtensionValueArray::const_iterator unused;
-    return FindExtension(id_authorityKeyIdentifier, unused);
-}
-
-bool X509Certificate::HasSubjectKeyIdentifier() const
-{
-    if (HasExtensions() == false)
-        { return false; }
-
-    ExtensionValueArray::const_iterator unused;
-    return FindExtension(id_subjectPublicKeyIdentifier, unused);
-}
-
-bool X509Certificate::IsCertificateAuthority() const
-{
-    // BasicConstraints ::= SEQUENCE {
-    //   cA                    BOOLEAN DEFAULT FALSE,
-    //   pathLenConstraint     INTEGER (0..MAX) OPTIONAL
-    // }
-
-    ExtensionValueArray::const_iterator loc;
-    if (FindExtension(id_basicConstraints, loc))
-    {
+  if (m_authorityKeyIdentifier.get() == NULLPTR) {
+    m_authorityKeyIdentifier.reset(new KeyIdentifierValue);
+    if (HasExtensions()) {
+      ExtensionValueArray::const_iterator loc;
+      if (FindExtension(id_authorityKeyIdentifier, loc)) {
         const ExtensionValue& ext = *loc;
-        BasicConstraintValue basicConstraints(ext.m_critical);
+        KeyIdentifierValue& identifier = *m_authorityKeyIdentifier.get();
 
         ArraySource store(ext.m_value, ext.m_value.size(), true);
-        basicConstraints.BERDecode(store);
-
-        return basicConstraints.m_ca;
+        identifier.BERDecode(store);
+      }
     }
+  }
 
-    return false;
+  return *m_authorityKeyIdentifier.get();
 }
 
-bool X509Certificate::IsSelfSigned() const
-{
-    // IssuerUID and SubjectUID are optional
-    if (HasIssuerUniqueId() && HasSubjectUniqueId() &&
-        GetIssuerUniqueId() == GetSubjectUniqueId())
-        return true;
+const KeyIdentifierValue& X509Certificate::GetSubjectKeyIdentifier() const {
+  // OCTET STRING, encapsulates {
+  //   OCTET STRING
+  //     AE 22 75 36 0B F0 D2 37 CB D2 AB 5B 47 B7 9E B0
+  //     ED 15 E5 9A
+  //   }
+  // }
 
-    // AKI and SPKI are optional
-    if (HasAuthorityKeyIdentifier() && HasSubjectKeyIdentifier() &&
-        GetAuthorityKeyIdentifier() == GetSubjectKeyIdentifier())
-        return true;
+  if (m_subjectKeyIdentifier.get() == NULLPTR) {
+    m_subjectKeyIdentifier.reset(new KeyIdentifierValue);
+    if (HasExtensions()) {
+      ExtensionValueArray::const_iterator loc;
+      if (FindExtension(id_subjectPublicKeyIdentifier, loc)) {
+        const ExtensionValue& ext = *loc;
+        KeyIdentifierValue& identifier = *m_subjectKeyIdentifier.get();
 
-    // Distinguished Names
-    bool same = false;
-    if (m_issuerName.size() == m_subjectName.size())
-    {
-        RdnValueArray::const_iterator a = m_issuerName.begin();
-        RdnValueArray::const_iterator b = m_subjectName.begin();
-        RdnValueArray::const_iterator c = m_issuerName.end();
-
-        same = true;
-        while (a != c)
-        {
-            same = (a->m_value == b->m_value) && same;
-            ++a; ++b;
-        }
+        ArraySource store(ext.m_value, ext.m_value.size(), true);
+        identifier.BERDecode(store);
+      }
     }
+  }
 
-    return same;
+  return *m_subjectKeyIdentifier.get();
 }
 
-const KeyIdentifierValue& X509Certificate::GetAuthorityKeyIdentifier() const
-{
-    // OCTET STRING, encapsulates {
-    //   SEQUENCE {
-    //     [0]
-    //       AE 22 75 36 0B F0 D2 37 CB D2 AB 5B 47 B7 9E B0
-    //       ED 15 E5 9A
-    //   }
-    // }
-
-    if (m_authorityKeyIdentifier.get() == NULLPTR)
-    {
-        m_authorityKeyIdentifier.reset(new KeyIdentifierValue);
-        if (HasExtensions())
-        {
-            ExtensionValueArray::const_iterator loc;
-            if (FindExtension(id_authorityKeyIdentifier, loc))
-            {
-                const ExtensionValue& ext = *loc;
-                KeyIdentifierValue& identifier = *m_authorityKeyIdentifier.get();
-
-                ArraySource store(ext.m_value, ext.m_value.size(), true);
-                identifier.BERDecode(store);
-            }
-        }
-    }
-
-    return *m_authorityKeyIdentifier.get();
-}
-
-const KeyIdentifierValue& X509Certificate::GetSubjectKeyIdentifier() const
-{
-    // OCTET STRING, encapsulates {
-    //   OCTET STRING
-    //     AE 22 75 36 0B F0 D2 37 CB D2 AB 5B 47 B7 9E B0
-    //     ED 15 E5 9A
-    //   }
-    // }
-
-    if (m_subjectKeyIdentifier.get() == NULLPTR)
-    {
-        m_subjectKeyIdentifier.reset(new KeyIdentifierValue);
-        if (HasExtensions())
-        {
-            ExtensionValueArray::const_iterator loc;
-            if (FindExtension(id_subjectPublicKeyIdentifier, loc))
-            {
-                const ExtensionValue& ext = *loc;
-                KeyIdentifierValue& identifier = *m_subjectKeyIdentifier.get();
-
-                ArraySource store(ext.m_value, ext.m_value.size(), true);
-                identifier.BERDecode(store);
-            }
-        }
-    }
-
-    return *m_subjectKeyIdentifier.get();
-}
-
-void X509Certificate::GetIdentitiesFromSubjectUniqueId(IdentityValueArray& identityArray) const
-{
-    if (HasSubjectUniqueId())
-    {
-        IdentityValue identity(*m_subjectUid.get(), IdentityValue::UniqueId);
-        identityArray.push_back(identity);
-    }
-}
-
-void X509Certificate::GetIdentitiesFromSubjectPublicKeyId(IdentityValueArray& identityArray) const
-{
-    const KeyIdentifierValue& subjectKeyIdentifier = GetSubjectKeyIdentifier();
-    IdentityValue identity(id_subjectPublicKeyIdentifier, subjectKeyIdentifier.m_value, IdentityValue::SubjectPKI);
+void X509Certificate::GetIdentitiesFromSubjectUniqueId(
+    IdentityValueArray& identityArray) const {
+  if (HasSubjectUniqueId()) {
+    IdentityValue identity(*m_subjectUid.get(), IdentityValue::UniqueId);
     identityArray.push_back(identity);
+  }
 }
 
-void X509Certificate::GetIdentitiesFromSubjectDistName(IdentityValueArray& identityArray) const
-{
-    // The full readable string
-    {
-        std::ostringstream oss;
-        oss << GetSubjectDistinguishedName();
-        const std::string id(oss.str());
-
-        IdentityValue identity(id_distinguishedName, id, IdentityValue::SubjectDN);
-        identityArray.push_back(identity);
-    }
-
-    // Get the CommonName separately
-    {
-        const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
-        RdnValueArray::const_iterator first = rdnArray.begin();
-        RdnValueArray::const_iterator last = rdnArray.end();
-
-        while (first != last)
-        {
-            if (first->m_oid == id_commonName)
-            {
-                IdentityValue identity(id_commonName, first->m_value, IdentityValue::SubjectCN);
-                identityArray.push_back(identity);
-                break;  // Only one common name
-            }
-            ++first;
-        }
-    }
-
-    // Get the UniqueId separately
-    {
-        const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
-        RdnValueArray::const_iterator first = rdnArray.begin();
-        RdnValueArray::const_iterator last = rdnArray.end();
-
-        while (first != last)
-        {
-            if (first->m_oid == id_uniqueIdentifier)
-            {
-                IdentityValue identity(id_uniqueIdentifier, first->m_value, IdentityValue::SubjectUID);
-                identityArray.push_back(identity);
-                // Don't break due to multiple UniqueId's
-            }
-            ++first;
-        }
-    }
-
-    // Get the PKCS#9 email separately
-    {
-        const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
-        RdnValueArray::const_iterator first = rdnArray.begin();
-        RdnValueArray::const_iterator last = rdnArray.end();
-
-        while (first != last)
-        {
-            if (first->m_oid == id_pkcsEmail)
-            {
-                IdentityValue identity(id_pkcsEmail, first->m_value, IdentityValue::SubjectEmail);
-                identityArray.push_back(identity);
-                // Don't break due to multiple emails
-            }
-            ++first;
-        }
-    }
+void X509Certificate::GetIdentitiesFromSubjectPublicKeyId(
+    IdentityValueArray& identityArray) const {
+  const KeyIdentifierValue& subjectKeyIdentifier = GetSubjectKeyIdentifier();
+  IdentityValue identity(id_subjectPublicKeyIdentifier,
+                         subjectKeyIdentifier.m_value,
+                         IdentityValue::SubjectPKI);
+  identityArray.push_back(identity);
 }
 
-void X509Certificate::GetIdentitiesFromSubjectAltName(IdentityValueArray& identityArray) const
-{
-    ExtensionValueArray::const_iterator loc;
-    if (FindExtension(id_subjectAltName, loc))
-    {
-        const ExtensionValue& ext = *loc;
-        ArraySource store(ext.m_value, ext.m_value.size(), true);
-
-        BERSequenceDecoder seq(store);
-          while (! seq.EndReached())
-          {
-              byte choice;
-              if (! seq.Get(choice))
-                  BERDecodeError();
-
-              // GeneralName must be in range [0] otherName to [8] registeredID
-              if (choice < 0x80 || choice > 0x88)
-                  BERDecodeError();
-
-              size_t len;
-              if (! BERLengthDecode(seq, len))
-                  BERDecodeError();
-
-              SecByteBlock value(len);
-              seq.Get(value, value.size());
-
-              IdentityValue::IdentityEnum src;
-
-              switch (choice)
-              {
-                  case 0x80:
-                    src = IdentityValue::otherName;
-                    break;
-
-                  case 0x81:
-                    src = IdentityValue::rfc822Name;
-                    break;
-
-                  case 0x82:
-                    src = IdentityValue::dNSName;
-                    break;
-
-                  case 0x83:
-                    src = IdentityValue::x400Address;
-                    break;
-
-                  case 0x84:
-                    src = IdentityValue::directoryName;
-                    break;
-
-                  case 0x85:
-                    src = IdentityValue::ediPartyName;
-                    break;
-
-                  case 0x86:
-                    src = IdentityValue::uniformResourceIdentifier;
-                    break;
-
-                  case 0x87:
-                    src = IdentityValue::iPAddress;
-                    break;
-
-                  case 0x88:
-                    src = IdentityValue::registeredID;
-                    break;
-
-                  default:
-                    src = IdentityValue::InvalidIdentityEnum;
-                    break;
-              }
-
-              IdentityValue identity(id_subjectAltName, value, src);
-              identityArray.push_back(identity);
-          }
-        seq.MessageEnd();
-    }
-}
-
-void X509Certificate::GetIdentitiesFromNetscapeServer(IdentityValueArray& identityArray) const
-{
-    ExtensionValueArray::const_iterator loc;
-    if (FindExtension(id_netscapeServerName, loc))
-    {
-        const ExtensionValue& ext = *loc;
-        ArraySource store(ext.m_value, ext.m_value.size(), true);
-
-        BERSequenceDecoder seq(store);
-
-          SecByteBlock temp;
-          temp.resize(seq.MaxRetrievable());
-          seq.Get(BytePtr(temp), BytePtrSize(temp));
-
-          IdentityValue identity(id_netscapeServerName, temp, IdentityValue::nsServer);
-          identityArray.push_back(identity);
-
-        seq.MessageEnd();
-    }
-}
-
-const IdentityValueArray& X509Certificate::GetSubjectIdentities() const
-{
-    if (m_identities.get() == NULLPTR)
-    {
-        m_identities.reset(new IdentityValueArray);
-        IdentityValueArray identities;
-
-        GetIdentitiesFromSubjectUniqueId(identities);
-        GetIdentitiesFromSubjectDistName(identities);
-        GetIdentitiesFromSubjectPublicKeyId(identities);
-        GetIdentitiesFromSubjectAltName(identities);
-        GetIdentitiesFromNetscapeServer(identities);
-
-        std::swap(*m_identities.get(), identities);
-    }
-
-    return *m_identities.get();
-}
-
-const KeyUsageValueArray& X509Certificate::GetSubjectKeyUsage() const
-{
-    if (m_keyUsage.get() == NULLPTR)
-    {
-        m_keyUsage.reset(new KeyUsageValueArray);
-        KeyUsageValueArray keyUsages;
-
-        ExtensionValueArray::const_iterator loc;
-        if (FindExtension(id_keyUsage, loc))
-        {
-            const ExtensionValue& ext = *loc;
-            ArraySource store(ConstBytePtr(ext.m_value), BytePtrSize(ext.m_value), true);
-
-            SecByteBlock values;
-            word32 mask = 0, unused;
-            BERDecodeBitString(store, values, unused);
-
-            // BER decoding due to Truswave certificates, https://github.com/noloader/cryptopp-pem/issues/15
-            // https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/EKAIB01lvlo/m/OJ10fvGMAwAJ
-            CRYPTOPP_ASSERT(values.size() == 1 || values.size() == 2);
-            CRYPTOPP_ASSERT(unused >= 0 && unused <= 7);
-
-            // The shift right followed by shift left accomplishes two goals.
-            // First, ensure the lower unused bits are actually 0. Second,
-            // the mask is 9 bits long regardless of 1 or 2 octets, or number
-            // of unused bits.
-            if (values.size() == 1) {
-                CRYPTOPP_ASSERT(values[0] != 0);
-                mask = (word32)values[0];
-                mask = (mask >> unused) << (unused + 1);
-            }
-            else if (values.size() == 2) {
-                CRYPTOPP_ASSERT(values[1] != 0);
-                mask = ((word32)values[0] << 8) | (word32)values[1];
-                mask = (mask >> unused) << (unused - 7);
-            }
-            else {
-                BERDecodeError();
-            }
-
-            // RFC 5280, Section 4.2.1.3
-            const KeyUsageValue::KeyUsageEnum usageEnum[] = {
-                KeyUsageValue::digitalSignature,    // MSB, pos 0
-                KeyUsageValue::nonRepudiation,
-                KeyUsageValue::keyEncipherment,
-                KeyUsageValue::dataEncipherment,
-                KeyUsageValue::keyAgreement,
-                KeyUsageValue::keyCertSign,
-                KeyUsageValue::cRLSign,
-                KeyUsageValue::encipherOnly,
-                KeyUsageValue::decipherOnly    // LSB, pos 8
-            };
-
-            const size_t count = COUNTOF(usageEnum);
-            for (size_t i=0; i<count; ++i)
-            {
-                if ((1 << (count - i - 1)) & mask)
-                {
-                    KeyUsageValue ku(id_keyUsage, usageEnum[i]);
-                    keyUsages.push_back(ku);
-                }
-            }
-        }
-
-        if (FindExtension(id_extendedKeyUsage, loc))
-        {
-            const ExtensionValue& ext = *loc;
-            ArraySource store(ConstBytePtr(ext.m_value), BytePtrSize(ext.m_value), true);
-
-            BERSequenceDecoder seq(store);
-
-              while (! seq.EndReached())
-              {
-                OID oid;
-                oid.BERDecode(seq);
-
-                KeyUsageValue eku(oid);
-                keyUsages.push_back(eku);
-              }
-            seq.MessageEnd();
-        }
-
-        std::swap(*m_keyUsage.get(), keyUsages);
-    }
-
-    return *m_keyUsage.get();
-}
-
-std::ostream& X509Certificate::Print(std::ostream& out) const
-{
+void X509Certificate::GetIdentitiesFromSubjectDistName(
+    IdentityValueArray& identityArray) const {
+  // The full readable string
+  {
     std::ostringstream oss;
-    std::ios_base::fmtflags base = out.flags() & std::ios_base::basefield;
+    oss << GetSubjectDistinguishedName();
+    const std::string id(oss.str());
 
-    oss << "Version: " << GetVersion() << std::endl;
-    oss << "Serial Number: " << "0x" << std::hex << GetSerialNumber() << std::endl;
-    oss.setf(base, std::ios_base::basefield);  // reset basefield
+    IdentityValue identity(id_distinguishedName, id, IdentityValue::SubjectDN);
+    identityArray.push_back(identity);
+  }
 
-    oss << "Not Before: " << GetNotBefore() << std::endl;
-    oss << "Not After: " << GetNotAfter() << std::endl;
+  // Get the CommonName separately
+  {
+    const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
+    RdnValueArray::const_iterator first = rdnArray.begin();
+    RdnValueArray::const_iterator last = rdnArray.end();
 
-    oss << "Issuer DN: " << GetIssuerDistinguishedName() << std::endl;
-    oss << "Subject DN: " << GetSubjectDistinguishedName() << std::endl;
+    while (first != last) {
+      if (first->m_oid == id_commonName) {
+        IdentityValue identity(id_commonName, first->m_value,
+                               IdentityValue::SubjectCN);
+        identityArray.push_back(identity);
+        break;  // Only one common name
+      }
+      ++first;
+    }
+  }
 
-    oss << "Authority KeyId: " << GetAuthorityKeyIdentifier() << std::endl;
-    oss << "Subject KeyId: " << GetSubjectKeyIdentifier() << std::endl;
+  // Get the UniqueId separately
+  {
+    const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
+    RdnValueArray::const_iterator first = rdnArray.begin();
+    RdnValueArray::const_iterator last = rdnArray.end();
 
-    oss << "Key Usage: " << GetSubjectKeyUsage() << std::endl;
+    while (first != last) {
+      if (first->m_oid == id_uniqueIdentifier) {
+        IdentityValue identity(id_uniqueIdentifier, first->m_value,
+                               IdentityValue::SubjectUID);
+        identityArray.push_back(identity);
+        // Don't break due to multiple UniqueId's
+      }
+      ++first;
+    }
+  }
 
-    oss << "CA Certificate: " << IsCertificateAuthority() << ", ";
-    oss << "Self Signed: " << IsSelfSigned() << std::endl;
+  // Get the PKCS#9 email separately
+  {
+    const RdnValueArray& rdnArray = GetSubjectDistinguishedName();
+    RdnValueArray::const_iterator first = rdnArray.begin();
+    RdnValueArray::const_iterator last = rdnArray.end();
 
-    // Format signature
-    std::string signature;
-    const SecByteBlock& binarySignature = GetCertificateSignature();
-    StringSource(binarySignature, binarySignature.size(), true, new HexEncoder(new StringSink(signature)));
-    signature.resize(60); signature += "...";
-
-    // Format tbs
-    std::string toBeSigned;
-    const SecByteBlock& binaryToBeSigned = GetToBeSigned();
-    StringSource(binaryToBeSigned, binaryToBeSigned.size(), true, new HexEncoder(new StringSink(toBeSigned)));
-    toBeSigned.resize(60); toBeSigned += "...";
-
-    const OID& algorithm = GetCertificateSignatureAlgorithm();
-    oss << "Signature Alg: " << OidToNameLookup(algorithm) << std::endl;
-    oss << "To Be Signed: " << toBeSigned << std::endl;
-    oss << "Signature: " << signature;
-
-    return out << oss.str();
+    while (first != last) {
+      if (first->m_oid == id_pkcsEmail) {
+        IdentityValue identity(id_pkcsEmail, first->m_value,
+                               IdentityValue::SubjectEmail);
+        identityArray.push_back(identity);
+        // Don't break due to multiple emails
+      }
+      ++first;
+    }
+  }
 }
 
-void X509Certificate::WriteCertificateBytes(BufferedTransformation &bt) const
-{
-    try
-    {
-        bt.Put(m_origCertificate, m_origCertificate.size());
+void X509Certificate::GetIdentitiesFromSubjectAltName(
+    IdentityValueArray& identityArray) const {
+  ExtensionValueArray::const_iterator loc;
+  if (FindExtension(id_subjectAltName, loc)) {
+    const ExtensionValue& ext = *loc;
+    ArraySource store(ext.m_value, ext.m_value.size(), true);
+
+    BERSequenceDecoder seq(store);
+    while (!seq.EndReached()) {
+      byte choice;
+      if (!seq.Get(choice)) BERDecodeError();
+
+      // GeneralName must be in range [0] otherName to [8] registeredID
+      if (choice < 0x80 || choice > 0x88) BERDecodeError();
+
+      size_t len;
+      if (!BERLengthDecode(seq, len)) BERDecodeError();
+
+      SecByteBlock value(len);
+      seq.Get(value, value.size());
+
+      IdentityValue::IdentityEnum src;
+
+      switch (choice) {
+        case 0x80:
+          src = IdentityValue::otherName;
+          break;
+
+        case 0x81:
+          src = IdentityValue::rfc822Name;
+          break;
+
+        case 0x82:
+          src = IdentityValue::dNSName;
+          break;
+
+        case 0x83:
+          src = IdentityValue::x400Address;
+          break;
+
+        case 0x84:
+          src = IdentityValue::directoryName;
+          break;
+
+        case 0x85:
+          src = IdentityValue::ediPartyName;
+          break;
+
+        case 0x86:
+          src = IdentityValue::uniformResourceIdentifier;
+          break;
+
+        case 0x87:
+          src = IdentityValue::iPAddress;
+          break;
+
+        case 0x88:
+          src = IdentityValue::registeredID;
+          break;
+
+        default:
+          src = IdentityValue::InvalidIdentityEnum;
+          break;
+      }
+
+      IdentityValue identity(id_subjectAltName, value, src);
+      identityArray.push_back(identity);
     }
-    catch(const Exception&)
-    {
+    seq.MessageEnd();
+  }
+}
+
+void X509Certificate::GetIdentitiesFromNetscapeServer(
+    IdentityValueArray& identityArray) const {
+  ExtensionValueArray::const_iterator loc;
+  if (FindExtension(id_netscapeServerName, loc)) {
+    const ExtensionValue& ext = *loc;
+    ArraySource store(ext.m_value, ext.m_value.size(), true);
+
+    BERSequenceDecoder seq(store);
+
+    SecByteBlock temp;
+    temp.resize(seq.MaxRetrievable());
+    seq.Get(BytePtr(temp), BytePtrSize(temp));
+
+    IdentityValue identity(id_netscapeServerName, temp,
+                           IdentityValue::nsServer);
+    identityArray.push_back(identity);
+
+    seq.MessageEnd();
+  }
+}
+
+const IdentityValueArray& X509Certificate::GetSubjectIdentities() const {
+  if (m_identities.get() == NULLPTR) {
+    m_identities.reset(new IdentityValueArray);
+    IdentityValueArray identities;
+
+    GetIdentitiesFromSubjectUniqueId(identities);
+    GetIdentitiesFromSubjectDistName(identities);
+    GetIdentitiesFromSubjectPublicKeyId(identities);
+    GetIdentitiesFromSubjectAltName(identities);
+    GetIdentitiesFromNetscapeServer(identities);
+
+    std::swap(*m_identities.get(), identities);
+  }
+
+  return *m_identities.get();
+}
+
+const KeyUsageValueArray& X509Certificate::GetSubjectKeyUsage() const {
+  if (m_keyUsage.get() == NULLPTR) {
+    m_keyUsage.reset(new KeyUsageValueArray);
+    KeyUsageValueArray keyUsages;
+
+    ExtensionValueArray::const_iterator loc;
+    if (FindExtension(id_keyUsage, loc)) {
+      const ExtensionValue& ext = *loc;
+      ArraySource store(ConstBytePtr(ext.m_value), BytePtrSize(ext.m_value),
+                        true);
+
+      SecByteBlock values;
+      word32 mask = 0, unused;
+      BERDecodeBitString(store, values, unused);
+
+      // BER decoding due to Truswave certificates,
+      // https://github.com/noloader/cryptopp-pem/issues/15
+      // https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/EKAIB01lvlo/m/OJ10fvGMAwAJ
+      CRYPTOPP_ASSERT(values.size() == 1 || values.size() == 2);
+      CRYPTOPP_ASSERT(unused >= 0 && unused <= 7);
+
+      // The shift right followed by shift left accomplishes two goals.
+      // First, ensure the lower unused bits are actually 0. Second,
+      // the mask is 9 bits long regardless of 1 or 2 octets, or number
+      // of unused bits.
+      if (values.size() == 1) {
+        CRYPTOPP_ASSERT(values[0] != 0);
+        mask = (word32)values[0];
+        mask = (mask >> unused) << (unused + 1);
+      } else if (values.size() == 2) {
+        CRYPTOPP_ASSERT(values[1] != 0);
+        mask = ((word32)values[0] << 8) | (word32)values[1];
+        mask = (mask >> unused) << (unused - 7);
+      } else {
+        BERDecodeError();
+      }
+
+      // RFC 5280, Section 4.2.1.3
+      const KeyUsageValue::KeyUsageEnum usageEnum[] = {
+          KeyUsageValue::digitalSignature,  // MSB, pos 0
+          KeyUsageValue::nonRepudiation,   KeyUsageValue::keyEncipherment,
+          KeyUsageValue::dataEncipherment, KeyUsageValue::keyAgreement,
+          KeyUsageValue::keyCertSign,      KeyUsageValue::cRLSign,
+          KeyUsageValue::encipherOnly,
+          KeyUsageValue::decipherOnly  // LSB, pos 8
+      };
+
+      const size_t count = COUNTOF(usageEnum);
+      for (size_t i = 0; i < count; ++i) {
+        if ((1 << (count - i - 1)) & mask) {
+          KeyUsageValue ku(id_keyUsage, usageEnum[i]);
+          keyUsages.push_back(ku);
+        }
+      }
     }
+
+    if (FindExtension(id_extendedKeyUsage, loc)) {
+      const ExtensionValue& ext = *loc;
+      ArraySource store(ConstBytePtr(ext.m_value), BytePtrSize(ext.m_value),
+                        true);
+
+      BERSequenceDecoder seq(store);
+
+      while (!seq.EndReached()) {
+        OID oid;
+        oid.BERDecode(seq);
+
+        KeyUsageValue eku(oid);
+        keyUsages.push_back(eku);
+      }
+      seq.MessageEnd();
+    }
+
+    std::swap(*m_keyUsage.get(), keyUsages);
+  }
+
+  return *m_keyUsage.get();
+}
+
+std::ostream& X509Certificate::Print(std::ostream& out) const {
+  std::ostringstream oss;
+  std::ios_base::fmtflags base = out.flags() & std::ios_base::basefield;
+
+  oss << "Version: " << GetVersion() << std::endl;
+  oss << "Serial Number: "
+      << "0x" << std::hex << GetSerialNumber() << std::endl;
+  oss.setf(base, std::ios_base::basefield);  // reset basefield
+
+  oss << "Not Before: " << GetNotBefore() << std::endl;
+  oss << "Not After: " << GetNotAfter() << std::endl;
+
+  oss << "Issuer DN: " << GetIssuerDistinguishedName() << std::endl;
+  oss << "Subject DN: " << GetSubjectDistinguishedName() << std::endl;
+
+  oss << "Authority KeyId: " << GetAuthorityKeyIdentifier() << std::endl;
+  oss << "Subject KeyId: " << GetSubjectKeyIdentifier() << std::endl;
+
+  oss << "Key Usage: " << GetSubjectKeyUsage() << std::endl;
+
+  oss << "CA Certificate: " << IsCertificateAuthority() << ", ";
+  oss << "Self Signed: " << IsSelfSigned() << std::endl;
+
+  // Format signature
+  std::string signature;
+  const SecByteBlock& binarySignature = GetCertificateSignature();
+  StringSource(binarySignature, binarySignature.size(), true,
+               new HexEncoder(new StringSink(signature)));
+  signature.resize(60);
+  signature += "...";
+
+  // Format tbs
+  std::string toBeSigned;
+  const SecByteBlock& binaryToBeSigned = GetToBeSigned();
+  StringSource(binaryToBeSigned, binaryToBeSigned.size(), true,
+               new HexEncoder(new StringSink(toBeSigned)));
+  toBeSigned.resize(60);
+  toBeSigned += "...";
+
+  const OID& algorithm = GetCertificateSignatureAlgorithm();
+  oss << "Signature Alg: " << OidToNameLookup(algorithm) << std::endl;
+  oss << "To Be Signed: " << toBeSigned << std::endl;
+  oss << "Signature: " << signature;
+
+  return out << oss.str();
+}
+
+void X509Certificate::WriteCertificateBytes(BufferedTransformation& bt) const {
+  try {
+    bt.Put(m_origCertificate, m_origCertificate.size());
+  } catch (const Exception&) {
+  }
 }
 
 NAMESPACE_END  // Cryptopp

--- a/lib/cryptopp-pem/cryptopp/x509cert.h
+++ b/lib/cryptopp-pem/cryptopp/x509cert.h
@@ -13,7 +13,8 @@
 /// \details This is a library add-on. You must download and compile it
 ///  yourself as part of the library.
 /// \since Crypto++ 8.3
-/// \sa <A HREF="http://www.cryptopp.com/wiki/X509Certificate">X509Certificate</A>
+/// \sa <A
+/// HREF="http://www.cryptopp.com/wiki/X509Certificate">X509Certificate</A>
 ///  and <A HREF="http://www.cryptopp.com/wiki/PEM_Pack">PEM Pack</A> on the
 ///  Crypto++ wiki.
 
@@ -22,15 +23,15 @@
 #ifndef CRYPTOPP_X509_CERTIFICATE_H
 #define CRYPTOPP_X509_CERTIFICATE_H
 
+#include <cryptopp/asn.h>
 #include <cryptopp/cryptlib.h>
 #include <cryptopp/secblock.h>
 #include <cryptopp/stdcpp.h>
-#include <cryptopp/asn.h>
 
 #include <iosfwd>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 NAMESPACE_BEGIN(CryptoPP)
 
@@ -41,9 +42,10 @@ class Integer;
 /// \param oid the object identifier
 /// \param defaultName the name to use if lookup fails
 /// \returns the LDAP name for display
-/// \details LDAP names are specified in ITU X.520 and other places, like the RFCs.
+/// \details LDAP names are specified in ITU X.520 and other places, like the
+/// RFCs.
 ///  If defaultName is NULL, then the OID is used.
-std::string OidToNameLookup(const OID& oid, const char *defaultName=NULLPTR);
+std::string OidToNameLookup(const OID &oid, const char *defaultName = NULLPTR);
 
 /// \brief ASNTag initializer
 /// \details 0 is an invalid tag value
@@ -52,27 +54,26 @@ const ASNTag InvalidTag = static_cast<ASNTag>(0);
 //////////////////////////////////////////////////
 
 /// \brief X.500 Relative Distinguished Name value
-struct RdnValue : public ASN1Object
-{
-    virtual ~RdnValue() {}
-    RdnValue() : m_tag(InvalidTag) {}
+struct RdnValue : public ASN1Object {
+  virtual ~RdnValue() {}
+  RdnValue() : m_tag(InvalidTag) {}
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    bool ValidateTag(byte tag) const;
+  bool ValidateTag(byte tag) const;
 
-    /// \brief Print an RDN value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an RDN value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    OID m_oid;
-    SecByteBlock m_value;
-    ASNTag m_tag;
+  OID m_oid;
+  SecByteBlock m_value;
+  ASNTag m_tag;
 };
 
 /// \brief Array of Relative Distinguished Name values
@@ -83,53 +84,51 @@ typedef std::vector<RdnValue> RdnValueArray;
 //////////////////////////////////////////////////
 
 /// \brief X.690 Date value
-struct DateValue : public ASN1Object
-{
-    DateValue() : m_tag(InvalidTag) {}
-    virtual ~DateValue() {}
+struct DateValue : public ASN1Object {
+  DateValue() : m_tag(InvalidTag) {}
+  virtual ~DateValue() {}
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    bool ValidateTag(byte tag) const;
+  bool ValidateTag(byte tag) const;
 
-    /// \brief Print a Date value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print a Date value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    SecByteBlock m_value;
-    ASNTag m_tag;
+  SecByteBlock m_value;
+  ASNTag m_tag;
 };
 
 //////////////////////////////////////////////////
 
 /// \brief X.509 Extension value
-struct ExtensionValue : public ASN1Object
-{
-    virtual ~ExtensionValue() {}
-    ExtensionValue() : m_tag(InvalidTag), m_critical(false) {}
+struct ExtensionValue : public ASN1Object {
+  virtual ~ExtensionValue() {}
+  ExtensionValue() : m_tag(InvalidTag), m_critical(false) {}
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    bool ValidateTag(byte tag) const;
+  bool ValidateTag(byte tag) const;
 
-    /// \brief Print an Extension value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an Extension value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    OID m_oid;
-    SecByteBlock m_value;
-    ASNTag m_tag;
-    bool m_critical;
+  OID m_oid;
+  SecByteBlock m_value;
+  ASNTag m_tag;
+  bool m_critical;
 };
 
 /// \brief Array of X.509 Extension values
@@ -140,39 +139,41 @@ typedef std::vector<ExtensionValue> ExtensionValueArray;
 //////////////////////////////////////////////////
 
 /// \brief X.509 KeyIdentifier value
-struct KeyIdentifierValue : public ASN1Object
-{
-    enum KeyIdentifierEnum {
-        /// \brief Hash of the public key
-        Hash=1,
-        /// \brief Distinguised name and serial number
-        DnAndSn
-    };
-    /// \brief Invalid identifier
-    static const KeyIdentifierEnum InvalidKeyIdentifier = static_cast<KeyIdentifierEnum>(0);
+struct KeyIdentifierValue : public ASN1Object {
+  enum KeyIdentifierEnum {
+    /// \brief Hash of the public key
+    Hash = 1,
+    /// \brief Distinguised name and serial number
+    DnAndSn
+  };
+  /// \brief Invalid identifier
+  static const KeyIdentifierEnum InvalidKeyIdentifier =
+      static_cast<KeyIdentifierEnum>(0);
+  static constexpr uint8_t CONSTRUCTED_AND_SEQUENCE =
+      (static_cast<uint8_t>(CONSTRUCTED) | static_cast<uint8_t>(SEQUENCE));
 
-    virtual ~KeyIdentifierValue() {}
-    KeyIdentifierValue() : m_type(InvalidKeyIdentifier) {}
+  virtual ~KeyIdentifierValue() {}
+  KeyIdentifierValue() : m_type(InvalidKeyIdentifier) {}
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    bool ValidateTag(byte tag) const;
+  bool ValidateTag(byte tag) const;
 
-    /// \brief Print an Extension value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an Extension value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    // The hash of the key is placed in m_value.
-    // The remaining bits, like DN and Serno, are placed in m_other.
-    OID m_oid;
-    SecByteBlock m_value;
-    SecByteBlock m_other;  // raw
-    KeyIdentifierEnum m_type;
+  // The hash of the key is placed in m_value.
+  // The remaining bits, like DN and Serno, are placed in m_other.
+  OID m_oid;
+  SecByteBlock m_value;
+  SecByteBlock m_other;  // raw
+  KeyIdentifierEnum m_type;
 };
 
 //////////////////////////////////////////////////
@@ -180,127 +181,134 @@ struct KeyIdentifierValue : public ASN1Object
 /// \brief X.509 KU and EKU value
 /// \details KeyUsageValue represents Key Usage and Extended Key Usage values
 /// \sa KeyUsageValueArray
-struct KeyUsageValue : public ASN1Object
-{
-    // https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml#smi-numbers-1.3.6.1.5.5.7.3
-    enum KeyUsageEnum {
-        /// \brief Digital signature
-        digitalSignature=0,
-        /// \brief Signature verification
-        /// \details nonRepudiation applies to non-certificate data
-        nonRepudiation=1,
-        /// \brief Signature verification
-        /// \details contentCommitment is nonRepudiation and applies to non-certificate data
-        contentCommitment=nonRepudiation,
-        /// \brief Key transport
-        keyEncipherment,
-        /// \brief Data encryption
-        /// \details Encryption occurs with the public key, and not a symmetric key
-        dataEncipherment,
-        /// \brief Key agreement
-        keyAgreement,
-        /// \brief Certificate signature verification
-        keyCertSign,
-        /// \brief Certificate revocation list signature verification
-        cRLSign,
-        /// \brief Data encryption
-        /// \details Data encryption occurs with a key agreement key
-        encipherOnly,
-        /// \brief Data decryption
-        /// \details Data decryption occurs with a key agreement key
-        decipherOnly,
-        /// \brief TLS server authentication
-        serverAuth,
-        /// \brief TLS client authentication
-        clientAuth,
-        /// \brief Code signing
-        codeSigning,
-        /// \brief Email protection
-        emailProtection,
-        /// \brief IPsec end system
-        ipsecEndSystem,
-        /// \brief IPsec tunnel
-        ipsecTunnel,
-        /// \brief IPsec user
-        ipsecUser,
-        /// \brief Time stamping
-        timeStamping,
-        /// \brief OCSP signing
-        OCSPSigning,
-        /// \brief Data Validation and Certification Server
-        dvcs,
-        /// \brief Border gateway CA server
-        sbgpCertAAServerAuth,
-        /// \brief SCVP responder
-        scvpResponder,
-        /// \brief Extensible Authentication Protocol (EAP) over PPP
-        eapOverPPP,
-        /// \brief Extensible Authentication Protocol (EAP) over LAN
-        eapOverLAN,
-        /// \brief Server-Based Certificate Validation Protocol
-        scvpServer,
-        /// \brief Server-Based Certificate Validation Protocol
-        scvpClient,
-        /// \brief IPsec Internet Key Exchange
-        ipsecIKE,
-        /// \brief Control And Provisioning of Wireless Access Points (CAPWAP) Protocol
-        capwapAC,
-        /// \brief Control And Provisioning of Wireless Access Points (CAPWAP) Protocol
-        capwapWTP,
-        /// \brief Session Initiation Protocol (SIP) X.509 Certificates
-        sipDomain,
-        /// \brief X.509v3 Certificates for Secure Shell Authentication
-        secureShellClient,
-        /// \brief X.509v3 Certificates for Secure Shell Authentication
-        secureShellServer,
-        /// \brief Certificate Profile and Certificate Management for SEcure Neighbor Discovery (SEND)
-        sendRouter,
-        /// \brief Certificate Profile and Certificate Management for SEcure Neighbor Discovery (SEND)
-        sendProxiedRouter,
-        /// \brief Certificate Profile and Certificate Management for SEcure Neighbor Discovery (SEND)
-        sendOwner,
-        /// \brief Certificate Profile and Certificate Management for SEcure Neighbor Discovery (SEND)
-        sendProxiedOwner,
-        /// \brief Certificate Management over CMS
-        cmcCA,
-        /// \brief Certificate Management over CMS
-        cmcRA,
-        /// \brief Certificate Management over CMS
-        cmcArchive,
-        /// \brief BGPsec Router Certificates, Certificate Revocation Lists, and Certification Requests
-        bgpsecRouter,
-        /// \brief Certificate profile for carrying logotypes
-        brandIndicatorforMessageIdentification
-    };
-    /// \brief Invalid key usage
-    static const KeyUsageEnum InvalidKeyUsage = static_cast<KeyUsageEnum>(128);
+struct KeyUsageValue : public ASN1Object {
+  // https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml#smi-numbers-1.3.6.1.5.5.7.3
+  enum KeyUsageEnum {
+    /// \brief Digital signature
+    digitalSignature = 0,
+    /// \brief Signature verification
+    /// \details nonRepudiation applies to non-certificate data
+    nonRepudiation = 1,
+    /// \brief Signature verification
+    /// \details contentCommitment is nonRepudiation and applies to
+    /// non-certificate data
+    contentCommitment = nonRepudiation,
+    /// \brief Key transport
+    keyEncipherment,
+    /// \brief Data encryption
+    /// \details Encryption occurs with the public key, and not a symmetric key
+    dataEncipherment,
+    /// \brief Key agreement
+    keyAgreement,
+    /// \brief Certificate signature verification
+    keyCertSign,
+    /// \brief Certificate revocation list signature verification
+    cRLSign,
+    /// \brief Data encryption
+    /// \details Data encryption occurs with a key agreement key
+    encipherOnly,
+    /// \brief Data decryption
+    /// \details Data decryption occurs with a key agreement key
+    decipherOnly,
+    /// \brief TLS server authentication
+    serverAuth,
+    /// \brief TLS client authentication
+    clientAuth,
+    /// \brief Code signing
+    codeSigning,
+    /// \brief Email protection
+    emailProtection,
+    /// \brief IPsec end system
+    ipsecEndSystem,
+    /// \brief IPsec tunnel
+    ipsecTunnel,
+    /// \brief IPsec user
+    ipsecUser,
+    /// \brief Time stamping
+    timeStamping,
+    /// \brief OCSP signing
+    OCSPSigning,
+    /// \brief Data Validation and Certification Server
+    dvcs,
+    /// \brief Border gateway CA server
+    sbgpCertAAServerAuth,
+    /// \brief SCVP responder
+    scvpResponder,
+    /// \brief Extensible Authentication Protocol (EAP) over PPP
+    eapOverPPP,
+    /// \brief Extensible Authentication Protocol (EAP) over LAN
+    eapOverLAN,
+    /// \brief Server-Based Certificate Validation Protocol
+    scvpServer,
+    /// \brief Server-Based Certificate Validation Protocol
+    scvpClient,
+    /// \brief IPsec Internet Key Exchange
+    ipsecIKE,
+    /// \brief Control And Provisioning of Wireless Access Points (CAPWAP)
+    /// Protocol
+    capwapAC,
+    /// \brief Control And Provisioning of Wireless Access Points (CAPWAP)
+    /// Protocol
+    capwapWTP,
+    /// \brief Session Initiation Protocol (SIP) X.509 Certificates
+    sipDomain,
+    /// \brief X.509v3 Certificates for Secure Shell Authentication
+    secureShellClient,
+    /// \brief X.509v3 Certificates for Secure Shell Authentication
+    secureShellServer,
+    /// \brief Certificate Profile and Certificate Management for SEcure
+    /// Neighbor Discovery (SEND)
+    sendRouter,
+    /// \brief Certificate Profile and Certificate Management for SEcure
+    /// Neighbor Discovery (SEND)
+    sendProxiedRouter,
+    /// \brief Certificate Profile and Certificate Management for SEcure
+    /// Neighbor Discovery (SEND)
+    sendOwner,
+    /// \brief Certificate Profile and Certificate Management for SEcure
+    /// Neighbor Discovery (SEND)
+    sendProxiedOwner,
+    /// \brief Certificate Management over CMS
+    cmcCA,
+    /// \brief Certificate Management over CMS
+    cmcRA,
+    /// \brief Certificate Management over CMS
+    cmcArchive,
+    /// \brief BGPsec Router Certificates, Certificate Revocation Lists, and
+    /// Certification Requests
+    bgpsecRouter,
+    /// \brief Certificate profile for carrying logotypes
+    brandIndicatorforMessageIdentification
+  };
+  /// \brief Invalid key usage
+  static const KeyUsageEnum InvalidKeyUsage = static_cast<KeyUsageEnum>(128);
 
-    virtual ~KeyUsageValue() {}
+  virtual ~KeyUsageValue() {}
 
-    /// \brief Construct a KeyUsageValue
-    /// \details Use this ctor for Extended Key Usage (EKU).
-    ///  KeyUsageEnum can be looked up based on a unique OID.
-    KeyUsageValue(const OID& oid);
+  /// \brief Construct a KeyUsageValue
+  /// \details Use this ctor for Extended Key Usage (EKU).
+  ///  KeyUsageEnum can be looked up based on a unique OID.
+  KeyUsageValue(const OID &oid);
 
-    /// \brief Construct a KeyUsageValue
-    /// \details Use this ctor for Key Usage (KU). KeyUsageEnum
-    ///  bitmask is a value of a common OID.
-    KeyUsageValue(const OID& oid, KeyUsageEnum usage);
+  /// \brief Construct a KeyUsageValue
+  /// \details Use this ctor for Key Usage (KU). KeyUsageEnum
+  ///  bitmask is a value of a common OID.
+  KeyUsageValue(const OID &oid, KeyUsageEnum usage);
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    /// \brief Print an Extension value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an Extension value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    OID m_oid;
-    // SecByteBlock m_value;
-    KeyUsageEnum m_usage;
+  OID m_oid;
+  // SecByteBlock m_value;
+  KeyUsageEnum m_usage;
 };
 
 /// \brief Array of X.509 Key usage values
@@ -311,112 +319,116 @@ typedef std::vector<KeyUsageValue> KeyUsageValueArray;
 //////////////////////////////////////////////////
 
 /// \brief X.509 Basic Constraint
-struct BasicConstraintValue : public ASN1Object
-{
-    virtual ~BasicConstraintValue() {}
-    BasicConstraintValue(bool critical=true) : m_pathLen(0), m_critical(critical), m_ca(false) {}
+struct BasicConstraintValue : public ASN1Object {
+  virtual ~BasicConstraintValue() {}
+  BasicConstraintValue(bool critical = true)
+      : m_pathLen(0), m_critical(critical), m_ca(false) {}
 
-    void BERDecode(BufferedTransformation &bt);
-    void DEREncode(BufferedTransformation &bt) const;
+  void BERDecode(BufferedTransformation &bt);
+  void DEREncode(BufferedTransformation &bt) const;
 
-    /// \brief Print an Extension value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an Extension value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    word32 m_pathLen;
-    bool m_critical, m_ca;
+  word32 m_pathLen;
+  bool m_critical, m_ca;
 };
 
 //////////////////////////////////////////////////
 
 /// \brief Identity value
-/// \details IdentityValue holds an identity and provides a textual representation of it.
-struct IdentityValue
-{
-    /// \brief Identity source
-    enum IdentityEnum {
-        /// \brief Subject Unique Identifier
-        /// \details Optional part of X.509 v2 specification
-        UniqueId=1,
-        /// \brief Subject Distinguished Name
-        /// \details Subject Distinguished Name (DN), which is a mashup of the RDNs
-        SubjectDN,
-        /// \brief Subject Common Name
-        /// \details Common Name RDN, optional part of Subject Distinguished Name (DN)
-        SubjectCN,
-        /// \brief Subject Unique Identifier
-        /// \details Subject Unique Identifier RDN, optional part of Subject Distinguished Name (DN)
-        SubjectUID,
-        /// \brief PKCS #9 email address
-        /// \details PKCS #9 Email RDN, optional part of Subject Distinguished Name (DN)
-        SubjectEmail,
-        /// \brief Subject Public Key Identifier (SPKI)
-        /// \details Optional part of X.509 v3 specification
-        SubjectPKI,
-        /// \brief SAN otherName
-        /// \details Optional Subject Alternate Name (SAN)
-        otherName,
-        /// \brief SAN rfc822Name
-        /// \details Optional Subject Alternate Name (SAN)
-        rfc822Name,
-        /// \brief SAN dNSName
-        /// \details Optional Subject Alternate Name (SAN)
-        dNSName,
-        /// \brief SAN x400Address
-        /// \details Optional Subject Alternate Name (SAN)
-        x400Address,
-        /// \brief SAN directoryName
-        /// \details Optional Subject Alternate Name (SAN)
-        directoryName,
-        /// \brief SAN ediPartyName
-        /// \details Optional Subject Alternate Name (SAN)
-        ediPartyName,
-        /// \brief SAN uniformResourceIdentifier
-        /// \details Optional Subject Alternate Name (SAN)
-        uniformResourceIdentifier,
-        /// \brief SAN iPAddress
-        /// \details Optional Subject Alternate Name (SAN)
-        iPAddress,
-        /// \brief SAN registeredID
-        /// \details Optional Subject Alternate Name (SAN)
-        registeredID,
-        /// \brief nsServer
-        /// \details Optional part of original Netscape specification
-        nsServer,
-        /// \brief msOtherNameUPN
-        /// \details Microsoft Kerberos UserPrincipalName extracted from SAN otherName
-        msOtherNameUPN
-    };
-    static const IdentityEnum InvalidIdentityEnum = static_cast<IdentityEnum>(0);
+/// \details IdentityValue holds an identity and provides a textual
+/// representation of it.
+struct IdentityValue {
+  /// \brief Identity source
+  enum IdentityEnum {
+    /// \brief Subject Unique Identifier
+    /// \details Optional part of X.509 v2 specification
+    UniqueId = 1,
+    /// \brief Subject Distinguished Name
+    /// \details Subject Distinguished Name (DN), which is a mashup of the RDNs
+    SubjectDN,
+    /// \brief Subject Common Name
+    /// \details Common Name RDN, optional part of Subject Distinguished Name
+    /// (DN)
+    SubjectCN,
+    /// \brief Subject Unique Identifier
+    /// \details Subject Unique Identifier RDN, optional part of Subject
+    /// Distinguished Name (DN)
+    SubjectUID,
+    /// \brief PKCS #9 email address
+    /// \details PKCS #9 Email RDN, optional part of Subject Distinguished Name
+    /// (DN)
+    SubjectEmail,
+    /// \brief Subject Public Key Identifier (SPKI)
+    /// \details Optional part of X.509 v3 specification
+    SubjectPKI,
+    /// \brief SAN otherName
+    /// \details Optional Subject Alternate Name (SAN)
+    otherName,
+    /// \brief SAN rfc822Name
+    /// \details Optional Subject Alternate Name (SAN)
+    rfc822Name,
+    /// \brief SAN dNSName
+    /// \details Optional Subject Alternate Name (SAN)
+    dNSName,
+    /// \brief SAN x400Address
+    /// \details Optional Subject Alternate Name (SAN)
+    x400Address,
+    /// \brief SAN directoryName
+    /// \details Optional Subject Alternate Name (SAN)
+    directoryName,
+    /// \brief SAN ediPartyName
+    /// \details Optional Subject Alternate Name (SAN)
+    ediPartyName,
+    /// \brief SAN uniformResourceIdentifier
+    /// \details Optional Subject Alternate Name (SAN)
+    uniformResourceIdentifier,
+    /// \brief SAN iPAddress
+    /// \details Optional Subject Alternate Name (SAN)
+    iPAddress,
+    /// \brief SAN registeredID
+    /// \details Optional Subject Alternate Name (SAN)
+    registeredID,
+    /// \brief nsServer
+    /// \details Optional part of original Netscape specification
+    nsServer,
+    /// \brief msOtherNameUPN
+    /// \details Microsoft Kerberos UserPrincipalName extracted from SAN
+    /// otherName
+    msOtherNameUPN
+  };
+  static const IdentityEnum InvalidIdentityEnum = static_cast<IdentityEnum>(0);
 
-    virtual ~IdentityValue() {}
+  virtual ~IdentityValue() {}
 
-    IdentityValue(const SecByteBlock &value, IdentityEnum src);
-    IdentityValue(const std::string &value, IdentityEnum src);
-    IdentityValue(const OID &oid, const SecByteBlock &value, IdentityEnum src);
-    IdentityValue(const OID &oid, const std::string &value, IdentityEnum src);
+  IdentityValue(const SecByteBlock &value, IdentityEnum src);
+  IdentityValue(const std::string &value, IdentityEnum src);
+  IdentityValue(const OID &oid, const SecByteBlock &value, IdentityEnum src);
+  IdentityValue(const OID &oid, const std::string &value, IdentityEnum src);
 
-    /// \brief Print an Identity value
-    /// \returns ostream reference
-    std::ostream& Print(std::ostream& out) const;
+  /// \brief Print an Identity value
+  /// \returns ostream reference
+  std::ostream &Print(std::ostream &out) const;
 
-    /// \brief Textual representation
-    /// \returns string representing the value
-    std::string EncodeValue() const;
+  /// \brief Textual representation
+  /// \returns string representing the value
+  std::string EncodeValue() const;
 
-    /// \brief Convert otherName into a different IdentityValue
-    /// \details ConvertOtherName() operates on this object.
-    ///  m_value and m_src can be changed to a new identity
-    ///  type, like a UPN string and msOtherNameUPN type.
-    void ConvertOtherName();
+  /// \brief Convert otherName into a different IdentityValue
+  /// \details ConvertOtherName() operates on this object.
+  ///  m_value and m_src can be changed to a new identity
+  ///  type, like a UPN string and msOtherNameUPN type.
+  void ConvertOtherName();
 
-    OID m_oid;
-    SecByteBlock m_value;  // Raw value from source
-    IdentityEnum m_src;
+  OID m_oid;
+  SecByteBlock m_value;  // Raw value from source
+  IdentityEnum m_src;
 };
 
 /// \brief Array of Identity values
@@ -435,439 +447,471 @@ typedef std::vector<IdentityValue> IdentityValueArray;
 ///  subjectPublicKeyInfo exposed as a X509PubliKey ready for use in Crypto++
 ///  library algorithms.
 /// \details Most member functions related to saving or encoding a certificate
-///  have not been cut-in. Calling member functions that have not been cut-in will
-///  result in NotImplemented exception. Future versions of the X509Certificate
-///  can provide them.
+///  have not been cut-in. Calling member functions that have not been cut-in
+///  will result in NotImplemented exception. Future versions of the
+///  X509Certificate can provide them.
 /// \throws NotImplemented if a particular function has not been cut-in. Member
 ///  functions that throw NotImplemented include <tt>DEREncode*</tt>.
 /// \details This is a library add-on. You must download and compile it
 ///  yourself as part of the library.
 /// \since Crypto++ 8.3
-/// \sa <A HREF="http://www.cryptopp.com/wiki/X509Certificate">X509Certificate</A>
+/// \sa <A
+/// HREF="http://www.cryptopp.com/wiki/X509Certificate">X509Certificate</A>
 ///  and <A HREF="http://www.cryptopp.com/wiki/PEM_Pack">PEM Pack</A> on the
 ///  Crypto++ wiki.
-class X509Certificate : public ASN1CryptoMaterial<Certificate>
-{
-public:
-
-    /// \brief Certificate version
-    enum Version {
-        /// \brief Version 1
-        v1=0,
-        /// \brief Version 2
-        v2,
-        /// \brief Version 3
-        v3
-    };
-
-public:
-    virtual ~X509Certificate() {}
-    X509Certificate() {}
-
-    // NameValuePairs
-    virtual void AssignFrom (const NameValuePairs &source);
-    virtual bool GetVoidValue (const char *name, const std::type_info &valueType, void *pValue) const;
-
-    /// \name VALIDATION
-    //@{
-
-    // CryptoMaterial
-    virtual bool Validate (RandomNumberGenerator &rng, unsigned int level) const;
-
-    /// \brief Validate signature on this certificate
-    /// \param rng a RandomNumberGenerator for objects which use randomized
-    ///  testing
-    /// \param key the public key of the keypair used to sign this certificate
-    /// \returns true if the test succeeds, false otherwise
-    /// \details If this certificate is self-signed then the signature can be
-    ///  verified using the public key in this certificate. In this case call
-    ///  ValidateSignature() with GetSubjectPublicKey().
-    /// \details If this certificate is signed by a CA certificate, then call
-    ///  ValidateSignature() using signing CA's public key. The CA's public
-    ///  key is found in the CA certificate using GetSubjectPublicKey().
-    /// \sa GetSubjectPublicKey
-    bool ValidateSignature (RandomNumberGenerator &rng, const X509PublicKey &key) const;
-
-    //@}
-
-    /// \name ENCODE/DECODE
-    //@{
-
-    // ASN1CryptoMaterial
-    virtual void Save (BufferedTransformation &bt) const;
-    virtual void Load (BufferedTransformation &bt);
-
-    // ASN1Object
-    virtual void BERDecode (BufferedTransformation &bt);
-    virtual void DEREncode (BufferedTransformation &bt) const;
-
-    //@}
-
-    /// \name ASN.1 OPTIONAL
-    //@{
-
-    /// \brief Determine if Issuer UniqueId is present
-    /// \returns true if Issuer UniqueId is present, false otherwise
-    /// \details Issuer UniqueId is optional and available with X.509 v2.
-    /// \sa HasSubjectUniqueId, GetIssuerUniqueId
-    bool HasIssuerUniqueId() const;
-
-    /// \brief Determine if Subject UniqueId is present
-    /// \returns true if Subject UniqueId is present, false otherwise
-    /// \details Subject UniqueId is optional and available with X.509 v2.
-    /// \sa HasIssuerUniqueId, GetSubjectUniqueId
-    bool HasSubjectUniqueId() const;
-
-    /// \brief Determine if Extensions are present
-    /// \returns true if Extensions are present, false otherwise
-    /// \details Extensions are optional and available with X.509 v3.
-    /// \sa GetExtensions
-    bool HasExtensions() const;
-
-    /// \brief Determine if AKI is present
-    /// \returns true if Authority Key Identifier is present, false otherwise
-    /// \details AKI is an optional extension and available with X.509 v3.
-    /// \sa HasSubjectKeyIdentifier, GetAuthorityKeyIdentifier
-    bool HasAuthorityKeyIdentifier() const;
-
-    /// \brief Determine if SPKI is present
-    /// \returns true if Subject Public Key Identifier is present, false otherwise
-    /// \details SPKI is an optional extension and available with X.509 v3.
-    /// \sa HasAuthorityKeyIdentifier, GetSubjectKeyIdentifier
-    bool HasSubjectKeyIdentifier() const;
-
-    //@}
-
-    /// \name ACCESSORS
-    //@{
-
-    /// \brief Retrieve complete DER encoded certicate
-    /// \returns the certificate data
-    /// \sa GetToBeSigned, GetCertificateSignature
-    const SecByteBlock& GetCertificate () const
-        { return m_origCertificate; }
-
-    /// \brief Retrieve DER encoded ToBeSigned
-    /// \returns the toBeSigned data
-    /// \sa GetCertificate, GetCertificateSignature
-    const SecByteBlock& GetToBeSigned () const;
-
-    /// \brief Version number
-    /// \returns Certificate version number
-    /// \note Version number is 0 based, so X.509 v3 value is 2.
-    Version GetVersion() const
-        { return m_version; }
-
-    /// \brief Serial number
-    /// \returns Certificate serial number
-    const Integer& GetSerialNumber() const
-        { return m_serialNumber; }
-
-    /// \brief Certificate signature algorithm
-    /// \returns Certificate signature algorithm
-    /// \sa GetCertificate, GetToBeSigned, GetCertificateSignature
-    const OID& GetCertificateSignatureAlgorithm() const
-        { return m_certSignatureAlgortihm; }
-
-    /// \brief Certificate signature
-    /// \returns Certificate signature
-    /// \sa GetCertificate, GetToBeSigned, GetCertificateSignatureAlgorithm
-    const SecByteBlock& GetCertificateSignature() const
-        { return m_certSignature; }
-
-    /// \brief Validity not before
-    /// \returns Validity not before
-    /// \sa GetNotAfter
-    const DateValue& GetNotBefore() const
-        { return m_notBefore; }
-
-    /// \brief Validity not after
-    /// \returns Validity not after
-    /// \sa GetNotBefore
-    const DateValue& GetNotAfter() const
-        { return m_notAfter; }
-
-    /// \brief Issuer distinguished name
-    /// \returns Issuer distinguished name
-    const RdnValueArray& GetIssuerDistinguishedName() const
-        { return m_issuerName; }
-
-    /// \brief Subject distinguished name
-    /// \returns Subject distinguished name
-    const RdnValueArray& GetSubjectDistinguishedName() const
-        { return m_subjectName; }
-
-    /// \brief Issuer UniqueId
-    /// \returns Issuer UniqueId
-    /// \details Issuer UniqueId is optional and available with X.509 v2.
-    /// \sa HasIssuerUniqueId
-    const SecByteBlock& GetIssuerUniqueId() const
-        { return m_issuerUid.get() ? *m_issuerUid.get() : g_nullByteBlock; }
-
-    /// \brief Subject UniqueId
-    /// \returns Subject UniqueId
-    /// \details Subject UniqueId is optional and available with X.509 v2.
-    /// \sa HasSubjectUniqueId
-    const SecByteBlock& GetSubjectUniqueId() const
-        { return m_subjectUid.get() ? *m_subjectUid.get() : g_nullByteBlock; }
-
-    /// \brief Certificate extensions
-    /// \returns Certificate extensions array
-    /// \details Certificate extensions are available with X.509 v3.
-    /// \sa HasExtensions
-    const ExtensionValueArray& GetExtensions() const
-        { return m_extensions.get() ? *m_extensions.get() : g_nullExtensions; }
-
-    /// \brief Subject public key algorithm
-    /// \returns Subject public key algorithm
-    /// \sa GetSubjectPublicKey
-    const OID& GetSubjectPublicKeyAlgorithm() const
-        { return m_subjectSignatureAlgortihm; }
-
-    /// \brief Subject public key
-    /// \returns Subject public key
-    /// \sa GetSubjectPublicKeyAlgorithm
-    const X509PublicKey& GetSubjectPublicKey() const
-        { return *m_subjectPublicKey.get(); }
-
-    /// \brief Authority key identifier
-    /// \returns Authority key identifier
-    /// \details Authority key identifier is optional and available with X.509 v3.
-    /// \sa HasAuthorityKeyIdentifier, GetSubjectKeyIdentifier
-    const KeyIdentifierValue& GetAuthorityKeyIdentifier() const;
-
-    /// \brief Subject key identifier
-    /// \returns Subject key identifier
-    /// \details Subject key identifier is optional and available with X.509 v3.
-    /// \sa HasSubjectKeyIdentifier, GetAuthorityKeyIdentifier
-    const KeyIdentifierValue& GetSubjectKeyIdentifier() const;
-
-    /// \brief Identities
-    /// \returns Identities
-    /// \details GetSubjectIdentities() collects the identities in the certificate.
-    const IdentityValueArray& GetSubjectIdentities() const;
-
-    /// \brief Identities
-    /// \returns Identities
-    /// \details GetSubjectIdentities() collects the identities in the certificate.
-    const KeyUsageValueArray& GetSubjectKeyUsage() const;
-
-    //@}
-
-    /// \name CERTIFICATE
-    //@{
-
-    /// \brief Determine if certificate is a CA
-    /// \returns true if the certificate is a CA, false otherwise
-    /// \details There are two types of certificates. The first is a CA certificate and
-    ///  signaled with <tt>basicConstraint, CA:TRUE</tt>. The second is an end entity
-    ///  certificate and signaled with <tt>basicConstraint, CA:FALSE</tt>.
-    ///  CA certificates can certify other certificates, while end entity certificates
-    ///  cannot. End entity certificates are leaf certificates.
-    /// \sa IsSelfSigned
-    bool IsCertificateAuthority() const;
-
-    /// \brief Determine if certificate is self-signed
-    /// \returns true if the certificate is self-signed, false otherwise
-    /// \sa IsCertificateAuthority
-    bool IsSelfSigned() const;
-
-    //@}
-
-    /// \name DEBUG
-    //@{
-
-    /// \brief Print a certificate
-    /// \param out ostream object
-    /// \returns ostream reference
-    /// \details Print() displays some of the fields of a certificate for
-    ///  debug purposes. Users should modify the class or override this
-    ///  class in a derived class to suit their taste.
-    virtual std::ostream& Print(std::ostream& out) const;
-
-    /// \brief Write certificate data
-    /// \param bt BufferedTransformation object
-    /// \details WriteCertificateBytes() is a debug function. It dumps
-    ///  the bytes stored in m_origCertificate. WriteCertificateBytes()
-    ///  also sets up a try/catch and silently swallows exceptions.
-    void WriteCertificateBytes(BufferedTransformation &bt) const;
-
-    //@}
-
-protected:
-    // Crib away the original certificate
-    void SaveCertificateBytes(BufferedTransformation &bt);
-    // Clear old certificate data
-    void Reset();
-
-    // RFC 2459, section 7.3.1, http://www.ietf.org/rfc/rfc2459.txt
-    virtual bool BERDecodeAlgorithmParameters (BufferedTransformation &bt)
-        {BERDecodeNull(bt); return false;}
-    virtual bool DEREncodeAlgorithmParameters (BufferedTransformation &bt) const
-        {DEREncodeNull(bt); return false;}
-
-    // X509Certificate
-    void BERDecodeVersion(BufferedTransformation &bt, Version &version);
-    void BERDecodeSerialNumber(BufferedTransformation &bt, Integer &serno);
-    void BERDecodeSignature(BufferedTransformation &bt, SecByteBlock &signature);
-    void BERDecodeSignatureAlgorithm(BufferedTransformation &bt, OID &algorithm);
-    void BERDecodeDistinguishedName(BufferedTransformation &bt, RdnValueArray &rdnArray);
-    void BERDecodeValidity(BufferedTransformation &bt, DateValue &notBefore, DateValue &notAfter);
-    void BERDecodeSubjectPublicKeyInfo(BufferedTransformation &bt, member_ptr<X509PublicKey>& publicKey);
-
-    // Optional attributes
-    bool HasOptionalAttribute(const BufferedTransformation &bt, byte tag) const;
-    void BERDecodeIssuerUniqueId(BufferedTransformation &bt);
-    void BERDecodeSubjectUniqueId(BufferedTransformation &bt);
-    void BERDecodeExtensions(BufferedTransformation &bt);
-
-    // BERDecodeSubjectPublicKeyInfo peeks at the subjectPublicKeyInfo because the
-    // information is less ambiguous. If we used subjectPublicKeyAlgorithm we would
-    // still need to peek because subjectPublicKeyAlgorithm lacks field information
-    // (prime vs. binary). We need a field to instantiate a key. For example,
-    // subjectPublicKeyAlgorithm==ecdsa_with_sha384() does not contain enough
-    // information to determine PublicKey_EC<ECP> or PublicKey_EC<EC2N>.
-    void GetSubjectPublicKeyInfoOids(const BufferedTransformation &bt, OID& algorithm, OID& field) const;
-
-    // Identity helper functions. Find them wherever we can.
-    void GetIdentitiesFromSubjectDistName(IdentityValueArray& identityArray) const;
-    void GetIdentitiesFromSubjectAltName(IdentityValueArray& identityArray) const;
-    void GetIdentitiesFromSubjectUniqueId(IdentityValueArray& identityArray) const;
-    void GetIdentitiesFromSubjectPublicKeyId(IdentityValueArray& identityArray) const;
-    void GetIdentitiesFromNetscapeServer(IdentityValueArray& identityArray) const;
-
-    // Find an extension with the OID. Returns false and end() if not found.
-    bool FindExtension(const OID& oid, ExtensionValueArray::const_iterator& loc) const;
-
-    // Get the verifier object for an algorithm and key
-    PK_Verifier* GetPK_VerifierObject(const OID &algorithm, const X509PublicKey &key) const;
-
-private:
-    // Version and serial number, required v1
-    Version m_version;
-    Integer m_serialNumber;
-
-    // Certificate algorithm and signature, required v1
-    OID m_certSignatureAlgortihm;
-    SecByteBlock m_certSignature;
-
-    // Issuer and subject DNs, required v1
-    RdnValueArray m_issuerName;
-    RdnValueArray m_subjectName;
-
-    // Validity dates, required v1
-    DateValue m_notBefore, m_notAfter;
-
-    // The subject's key and algorithm, required v1
-    OID m_subjectSignatureAlgortihm;
-    member_ptr<X509PublicKey> m_subjectPublicKey;
-
-    // Issue and Subject UniqueId, optional v2
-    ASNOptional<SecByteBlock> m_issuerUid;
-    ASNOptional<SecByteBlock> m_subjectUid;
-
-    // Extensions, optional v3
-    ASNOptional<ExtensionValueArray> m_extensions;
-
-    // AKI and SPKI extensions, optional v3
-    mutable member_ptr<KeyIdentifierValue> m_authorityKeyIdentifier;  // lazy
-    mutable member_ptr<KeyIdentifierValue> m_subjectKeyIdentifier;    // lazy
-
-    // KU and EKU, optional v3
-    mutable member_ptr<KeyUsageValueArray> m_keyUsage;  // lazy
-
-    // Identities
-    mutable member_ptr<IdentityValueArray> m_identities;  // lazy
-
-    // To be signed, required v1
-    mutable member_ptr<SecByteBlock> m_toBeSigned;  // lazy
-
-    // Hack so we can examine the octets. Also see WriteCertificateBytes.
-    SecByteBlock m_origCertificate;
-
-    // Null values so we can return something
-    static const SecByteBlock  g_nullByteBlock;
-    static const ExtensionValueArray g_nullExtensions;
+class X509Certificate : public ASN1CryptoMaterial<Certificate> {
+ public:
+  /// \brief Certificate version
+  enum Version {
+    /// \brief Version 1
+    v1 = 0,
+    /// \brief Version 2
+    v2,
+    /// \brief Version 3
+    v3
+  };
+
+ public:
+  virtual ~X509Certificate() {}
+  X509Certificate() {}
+
+  // NameValuePairs
+  virtual void AssignFrom(const NameValuePairs &source);
+  virtual bool GetVoidValue(const char *name, const std::type_info &valueType,
+                            void *pValue) const;
+
+  /// \name VALIDATION
+  //@{
+
+  // CryptoMaterial
+  virtual bool Validate(RandomNumberGenerator &rng, unsigned int level) const;
+
+  /// \brief Validate signature on this certificate
+  /// \param rng a RandomNumberGenerator for objects which use randomized
+  ///  testing
+  /// \param key the public key of the keypair used to sign this certificate
+  /// \returns true if the test succeeds, false otherwise
+  /// \details If this certificate is self-signed then the signature can be
+  ///  verified using the public key in this certificate. In this case call
+  ///  ValidateSignature() with GetSubjectPublicKey().
+  /// \details If this certificate is signed by a CA certificate, then call
+  ///  ValidateSignature() using signing CA's public key. The CA's public
+  ///  key is found in the CA certificate using GetSubjectPublicKey().
+  /// \sa GetSubjectPublicKey
+  bool ValidateSignature(RandomNumberGenerator &rng,
+                         const X509PublicKey &key) const;
+
+  //@}
+
+  /// \name ENCODE/DECODE
+  //@{
+
+  // ASN1CryptoMaterial
+  virtual void Save(BufferedTransformation &bt) const;
+  virtual void Load(BufferedTransformation &bt);
+
+  // ASN1Object
+  virtual void BERDecode(BufferedTransformation &bt);
+  virtual void DEREncode(BufferedTransformation &bt) const;
+
+  //@}
+
+  /// \name ASN.1 OPTIONAL
+  //@{
+
+  /// \brief Determine if Issuer UniqueId is present
+  /// \returns true if Issuer UniqueId is present, false otherwise
+  /// \details Issuer UniqueId is optional and available with X.509 v2.
+  /// \sa HasSubjectUniqueId, GetIssuerUniqueId
+  bool HasIssuerUniqueId() const;
+
+  /// \brief Determine if Subject UniqueId is present
+  /// \returns true if Subject UniqueId is present, false otherwise
+  /// \details Subject UniqueId is optional and available with X.509 v2.
+  /// \sa HasIssuerUniqueId, GetSubjectUniqueId
+  bool HasSubjectUniqueId() const;
+
+  /// \brief Determine if Extensions are present
+  /// \returns true if Extensions are present, false otherwise
+  /// \details Extensions are optional and available with X.509 v3.
+  /// \sa GetExtensions
+  bool HasExtensions() const;
+
+  /// \brief Determine if AKI is present
+  /// \returns true if Authority Key Identifier is present, false otherwise
+  /// \details AKI is an optional extension and available with X.509 v3.
+  /// \sa HasSubjectKeyIdentifier, GetAuthorityKeyIdentifier
+  bool HasAuthorityKeyIdentifier() const;
+
+  /// \brief Determine if SPKI is present
+  /// \returns true if Subject Public Key Identifier is present, false otherwise
+  /// \details SPKI is an optional extension and available with X.509 v3.
+  /// \sa HasAuthorityKeyIdentifier, GetSubjectKeyIdentifier
+  bool HasSubjectKeyIdentifier() const;
+
+  //@}
+
+  /// \name ACCESSORS
+  //@{
+
+  /// \brief Retrieve complete DER encoded certicate
+  /// \returns the certificate data
+  /// \sa GetToBeSigned, GetCertificateSignature
+  const SecByteBlock &GetCertificate() const { return m_origCertificate; }
+
+  /// \brief Retrieve DER encoded ToBeSigned
+  /// \returns the toBeSigned data
+  /// \sa GetCertificate, GetCertificateSignature
+  const SecByteBlock &GetToBeSigned() const;
+
+  /// \brief Version number
+  /// \returns Certificate version number
+  /// \note Version number is 0 based, so X.509 v3 value is 2.
+  Version GetVersion() const { return m_version; }
+
+  /// \brief Serial number
+  /// \returns Certificate serial number
+  const Integer &GetSerialNumber() const { return m_serialNumber; }
+
+  /// \brief Certificate signature algorithm
+  /// \returns Certificate signature algorithm
+  /// \sa GetCertificate, GetToBeSigned, GetCertificateSignature
+  const OID &GetCertificateSignatureAlgorithm() const {
+    return m_certSignatureAlgortihm;
+  }
+
+  /// \brief Certificate signature
+  /// \returns Certificate signature
+  /// \sa GetCertificate, GetToBeSigned, GetCertificateSignatureAlgorithm
+  const SecByteBlock &GetCertificateSignature() const {
+    return m_certSignature;
+  }
+
+  /// \brief Validity not before
+  /// \returns Validity not before
+  /// \sa GetNotAfter
+  const DateValue &GetNotBefore() const { return m_notBefore; }
+
+  /// \brief Validity not after
+  /// \returns Validity not after
+  /// \sa GetNotBefore
+  const DateValue &GetNotAfter() const { return m_notAfter; }
+
+  /// \brief Issuer distinguished name
+  /// \returns Issuer distinguished name
+  const RdnValueArray &GetIssuerDistinguishedName() const {
+    return m_issuerName;
+  }
+
+  /// \brief Subject distinguished name
+  /// \returns Subject distinguished name
+  const RdnValueArray &GetSubjectDistinguishedName() const {
+    return m_subjectName;
+  }
+
+  /// \brief Issuer UniqueId
+  /// \returns Issuer UniqueId
+  /// \details Issuer UniqueId is optional and available with X.509 v2.
+  /// \sa HasIssuerUniqueId
+  const SecByteBlock &GetIssuerUniqueId() const {
+    return m_issuerUid.get() ? *m_issuerUid.get() : g_nullByteBlock;
+  }
+
+  /// \brief Subject UniqueId
+  /// \returns Subject UniqueId
+  /// \details Subject UniqueId is optional and available with X.509 v2.
+  /// \sa HasSubjectUniqueId
+  const SecByteBlock &GetSubjectUniqueId() const {
+    return m_subjectUid.get() ? *m_subjectUid.get() : g_nullByteBlock;
+  }
+
+  /// \brief Certificate extensions
+  /// \returns Certificate extensions array
+  /// \details Certificate extensions are available with X.509 v3.
+  /// \sa HasExtensions
+  const ExtensionValueArray &GetExtensions() const {
+    return m_extensions.get() ? *m_extensions.get() : g_nullExtensions;
+  }
+
+  /// \brief Subject public key algorithm
+  /// \returns Subject public key algorithm
+  /// \sa GetSubjectPublicKey
+  const OID &GetSubjectPublicKeyAlgorithm() const {
+    return m_subjectSignatureAlgortihm;
+  }
+
+  /// \brief Subject public key
+  /// \returns Subject public key
+  /// \sa GetSubjectPublicKeyAlgorithm
+  const X509PublicKey &GetSubjectPublicKey() const {
+    return *m_subjectPublicKey.get();
+  }
+
+  /// \brief Authority key identifier
+  /// \returns Authority key identifier
+  /// \details Authority key identifier is optional and available with X.509 v3.
+  /// \sa HasAuthorityKeyIdentifier, GetSubjectKeyIdentifier
+  const KeyIdentifierValue &GetAuthorityKeyIdentifier() const;
+
+  /// \brief Subject key identifier
+  /// \returns Subject key identifier
+  /// \details Subject key identifier is optional and available with X.509 v3.
+  /// \sa HasSubjectKeyIdentifier, GetAuthorityKeyIdentifier
+  const KeyIdentifierValue &GetSubjectKeyIdentifier() const;
+
+  /// \brief Identities
+  /// \returns Identities
+  /// \details GetSubjectIdentities() collects the identities in the
+  /// certificate.
+  const IdentityValueArray &GetSubjectIdentities() const;
+
+  /// \brief Identities
+  /// \returns Identities
+  /// \details GetSubjectIdentities() collects the identities in the
+  /// certificate.
+  const KeyUsageValueArray &GetSubjectKeyUsage() const;
+
+  //@}
+
+  /// \name CERTIFICATE
+  //@{
+
+  /// \brief Determine if certificate is a CA
+  /// \returns true if the certificate is a CA, false otherwise
+  /// \details There are two types of certificates. The first is a CA
+  /// certificate and
+  ///  signaled with <tt>basicConstraint, CA:TRUE</tt>. The second is an end
+  ///  entity certificate and signaled with <tt>basicConstraint, CA:FALSE</tt>.
+  ///  CA certificates can certify other certificates, while end entity
+  ///  certificates cannot. End entity certificates are leaf certificates.
+  /// \sa IsSelfSigned
+  bool IsCertificateAuthority() const;
+
+  /// \brief Determine if certificate is self-signed
+  /// \returns true if the certificate is self-signed, false otherwise
+  /// \sa IsCertificateAuthority
+  bool IsSelfSigned() const;
+
+  //@}
+
+  /// \name DEBUG
+  //@{
+
+  /// \brief Print a certificate
+  /// \param out ostream object
+  /// \returns ostream reference
+  /// \details Print() displays some of the fields of a certificate for
+  ///  debug purposes. Users should modify the class or override this
+  ///  class in a derived class to suit their taste.
+  virtual std::ostream &Print(std::ostream &out) const;
+
+  /// \brief Write certificate data
+  /// \param bt BufferedTransformation object
+  /// \details WriteCertificateBytes() is a debug function. It dumps
+  ///  the bytes stored in m_origCertificate. WriteCertificateBytes()
+  ///  also sets up a try/catch and silently swallows exceptions.
+  void WriteCertificateBytes(BufferedTransformation &bt) const;
+
+  //@}
+
+ protected:
+  // Crib away the original certificate
+  void SaveCertificateBytes(BufferedTransformation &bt);
+  // Clear old certificate data
+  void Reset();
+
+  // RFC 2459, section 7.3.1, http://www.ietf.org/rfc/rfc2459.txt
+  virtual bool BERDecodeAlgorithmParameters(BufferedTransformation &bt) {
+    BERDecodeNull(bt);
+    return false;
+  }
+  virtual bool DEREncodeAlgorithmParameters(BufferedTransformation &bt) const {
+    DEREncodeNull(bt);
+    return false;
+  }
+
+  // X509Certificate
+  void BERDecodeVersion(BufferedTransformation &bt, Version &version);
+  void BERDecodeSerialNumber(BufferedTransformation &bt, Integer &serno);
+  void BERDecodeSignature(BufferedTransformation &bt, SecByteBlock &signature);
+  void BERDecodeSignatureAlgorithm(BufferedTransformation &bt, OID &algorithm);
+  void BERDecodeDistinguishedName(BufferedTransformation &bt,
+                                  RdnValueArray &rdnArray);
+  void BERDecodeValidity(BufferedTransformation &bt, DateValue &notBefore,
+                         DateValue &notAfter);
+  void BERDecodeSubjectPublicKeyInfo(BufferedTransformation &bt,
+                                     member_ptr<X509PublicKey> &publicKey);
+
+  // Optional attributes
+  bool HasOptionalAttribute(const BufferedTransformation &bt, byte tag) const;
+  void BERDecodeIssuerUniqueId(BufferedTransformation &bt);
+  void BERDecodeSubjectUniqueId(BufferedTransformation &bt);
+  void BERDecodeExtensions(BufferedTransformation &bt);
+
+  // BERDecodeSubjectPublicKeyInfo peeks at the subjectPublicKeyInfo because the
+  // information is less ambiguous. If we used subjectPublicKeyAlgorithm we
+  // would still need to peek because subjectPublicKeyAlgorithm lacks field
+  // information (prime vs. binary). We need a field to instantiate a key. For
+  // example, subjectPublicKeyAlgorithm==ecdsa_with_sha384() does not contain
+  // enough information to determine PublicKey_EC<ECP> or PublicKey_EC<EC2N>.
+  void GetSubjectPublicKeyInfoOids(const BufferedTransformation &bt,
+                                   OID &algorithm, OID &field) const;
+
+  // Identity helper functions. Find them wherever we can.
+  void GetIdentitiesFromSubjectDistName(
+      IdentityValueArray &identityArray) const;
+  void GetIdentitiesFromSubjectAltName(IdentityValueArray &identityArray) const;
+  void GetIdentitiesFromSubjectUniqueId(
+      IdentityValueArray &identityArray) const;
+  void GetIdentitiesFromSubjectPublicKeyId(
+      IdentityValueArray &identityArray) const;
+  void GetIdentitiesFromNetscapeServer(IdentityValueArray &identityArray) const;
+
+  // Find an extension with the OID. Returns false and end() if not found.
+  bool FindExtension(const OID &oid,
+                     ExtensionValueArray::const_iterator &loc) const;
+
+  // Get the verifier object for an algorithm and key
+  PK_Verifier *GetPK_VerifierObject(const OID &algorithm,
+                                    const X509PublicKey &key) const;
+
+ private:
+  // Version and serial number, required v1
+  Version m_version;
+  Integer m_serialNumber;
+
+  // Certificate algorithm and signature, required v1
+  OID m_certSignatureAlgortihm;
+  SecByteBlock m_certSignature;
+
+  // Issuer and subject DNs, required v1
+  RdnValueArray m_issuerName;
+  RdnValueArray m_subjectName;
+
+  // Validity dates, required v1
+  DateValue m_notBefore, m_notAfter;
+
+  // The subject's key and algorithm, required v1
+  OID m_subjectSignatureAlgortihm;
+  member_ptr<X509PublicKey> m_subjectPublicKey;
+
+  // Issue and Subject UniqueId, optional v2
+  ASNOptional<SecByteBlock> m_issuerUid;
+  ASNOptional<SecByteBlock> m_subjectUid;
+
+  // Extensions, optional v3
+  ASNOptional<ExtensionValueArray> m_extensions;
+
+  // AKI and SPKI extensions, optional v3
+  mutable member_ptr<KeyIdentifierValue> m_authorityKeyIdentifier;  // lazy
+  mutable member_ptr<KeyIdentifierValue> m_subjectKeyIdentifier;    // lazy
+
+  // KU and EKU, optional v3
+  mutable member_ptr<KeyUsageValueArray> m_keyUsage;  // lazy
+
+  // Identities
+  mutable member_ptr<IdentityValueArray> m_identities;  // lazy
+
+  // To be signed, required v1
+  mutable member_ptr<SecByteBlock> m_toBeSigned;  // lazy
+
+  // Hack so we can examine the octets. Also see WriteCertificateBytes.
+  SecByteBlock m_origCertificate;
+
+  // Null values so we can return something
+  static const SecByteBlock g_nullByteBlock;
+  static const ExtensionValueArray g_nullExtensions;
 };
 
 //////////////////////////////////////////////////
 
-inline std::ostream& operator<<(std::ostream& out, const X509Certificate &cert)
-    { return cert.Print(out); }
-inline std::ostream& operator<<(std::ostream& out, const RdnValue &value)
-    { return value.Print(out); }
-inline std::ostream& operator<<(std::ostream& out, const DateValue &value)
-    { return value.Print(out); }
-inline std::ostream& operator<<(std::ostream& out, const KeyIdentifierValue &value)
-    { return value.Print(out); }
-inline std::ostream& operator<<(std::ostream& out, const KeyUsageValue &value)
-    { return value.Print(out); }
-inline std::ostream& operator<<(std::ostream& out, const IdentityValue &value)
-    { return value.Print(out); }
-
-inline bool operator==(const RdnValue &first, const RdnValue &second)
-    { return first.m_value == second.m_value; }
-inline bool operator==(const KeyIdentifierValue &first, const KeyIdentifierValue &second)
-    { return first.m_value == second.m_value; }
-
-inline std::ostream& operator<<(std::ostream& out, const RdnValueArray &values)
-{
-    RdnValueArray::const_iterator first = values.begin();
-    RdnValueArray::const_iterator last = values.end();
-    std::ostringstream oss;
-
-    while (first != last)
-    {
-        oss << *first;
-        if (++first != last)
-            { oss << "; "; }
-    }
-    return out << oss.str();
+inline std::ostream &operator<<(std::ostream &out,
+                                const X509Certificate &cert) {
+  return cert.Print(out);
+}
+inline std::ostream &operator<<(std::ostream &out, const RdnValue &value) {
+  return value.Print(out);
+}
+inline std::ostream &operator<<(std::ostream &out, const DateValue &value) {
+  return value.Print(out);
+}
+inline std::ostream &operator<<(std::ostream &out,
+                                const KeyIdentifierValue &value) {
+  return value.Print(out);
+}
+inline std::ostream &operator<<(std::ostream &out, const KeyUsageValue &value) {
+  return value.Print(out);
+}
+inline std::ostream &operator<<(std::ostream &out, const IdentityValue &value) {
+  return value.Print(out);
 }
 
-inline std::ostream& operator<<(std::ostream& out, const IdentityValueArray &values)
-{
-    IdentityValueArray::const_iterator first = values.begin();
-    IdentityValueArray::const_iterator last = values.end();
-    std::ostringstream oss;
-
-    while (first != last)
-    {
-        oss << *first;
-        if (++first != last)
-            { oss << "\n"; }
-    }
-    return out << oss.str();
+inline bool operator==(const RdnValue &first, const RdnValue &second) {
+  return first.m_value == second.m_value;
+}
+inline bool operator==(const KeyIdentifierValue &first,
+                       const KeyIdentifierValue &second) {
+  return first.m_value == second.m_value;
 }
 
-inline std::ostream& operator<<(std::ostream& out, const KeyUsageValueArray &values)
-{
-    KeyUsageValueArray::const_iterator first = values.begin();
-    KeyUsageValueArray::const_iterator last = values.end();
-    std::ostringstream oss;
+inline std::ostream &operator<<(std::ostream &out,
+                                const RdnValueArray &values) {
+  RdnValueArray::const_iterator first = values.begin();
+  RdnValueArray::const_iterator last = values.end();
+  std::ostringstream oss;
 
-    while (first != last)
-    {
-        oss << *first;
-        if (++first != last)
-            { oss << ", "; }
+  while (first != last) {
+    oss << *first;
+    if (++first != last) {
+      oss << "; ";
     }
-    return out << oss.str();
+  }
+  return out << oss.str();
+}
+
+inline std::ostream &operator<<(std::ostream &out,
+                                const IdentityValueArray &values) {
+  IdentityValueArray::const_iterator first = values.begin();
+  IdentityValueArray::const_iterator last = values.end();
+  std::ostringstream oss;
+
+  while (first != last) {
+    oss << *first;
+    if (++first != last) {
+      oss << "\n";
+    }
+  }
+  return out << oss.str();
+}
+
+inline std::ostream &operator<<(std::ostream &out,
+                                const KeyUsageValueArray &values) {
+  KeyUsageValueArray::const_iterator first = values.begin();
+  KeyUsageValueArray::const_iterator last = values.end();
+  std::ostringstream oss;
+
+  while (first != last) {
+    oss << *first;
+    if (++first != last) {
+      oss << ", ";
+    }
+  }
+  return out << oss.str();
 }
 
 //////////////////////////////////////////////////
 
 // Make these defines to avoid global objects
-#define id_sha1WithRSASignature     (OID(1)+2+840+113549+1+1+5)
-#define id_sha256WithRSAEncryption  (OID(1)+2+840+113549+1+1+11)
-#define id_sha384WithRSAEncryption  (OID(1)+2+840+113549+1+1+12)
-#define id_sha512WithRSAEncryption  (OID(1)+2+840+113549+1+1+13)
+#define id_sha1WithRSASignature (OID(1) + 2 + 840 + 113549 + 1 + 1 + 5)
+#define id_sha256WithRSAEncryption (OID(1) + 2 + 840 + 113549 + 1 + 1 + 11)
+#define id_sha384WithRSAEncryption (OID(1) + 2 + 840 + 113549 + 1 + 1 + 12)
+#define id_sha512WithRSAEncryption (OID(1) + 2 + 840 + 113549 + 1 + 1 + 13)
 
-#define id_secp256v1        (OID(1)+2+840+10045+3+1+7)
-#define id_ecdsaWithSHA1    (OID(1)+2+840+10045+4+1)
-#define id_ecdsaWithSHA256  (OID(1)+2+840+10045+4+3+2)
-#define id_ecdsaWithSHA384  (OID(1)+2+840+10045+4+3+3)
-#define id_ecdsaWithSHA512  (OID(1)+2+840+10045+4+3+4)
+#define id_secp256v1 (OID(1) + 2 + 840 + 10045 + 3 + 1 + 7)
+#define id_ecdsaWithSHA1 (OID(1) + 2 + 840 + 10045 + 4 + 1)
+#define id_ecdsaWithSHA256 (OID(1) + 2 + 840 + 10045 + 4 + 3 + 2)
+#define id_ecdsaWithSHA384 (OID(1) + 2 + 840 + 10045 + 4 + 3 + 3)
+#define id_ecdsaWithSHA512 (OID(1) + 2 + 840 + 10045 + 4 + 3 + 4)
 
 NAMESPACE_END
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.0)
+
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include/JsonRpc
@@ -26,13 +28,15 @@ add_library(${LIB_NAME} STATIC
     include/ByteSerializers/BaseByteSerializer.cpp
 )
 
-#openssl comes from vcpkg or system
-#cryptopp-static comes from vcpkg or system
-#cryptopp_pem comes from local source tree
-#linking PUBLIC as we want headers from all those libs be accessible to all clients
+message("CRYPTOPP_LIBRARIES:" ${CRYPTOPP_LIBRARIES})
+
+# openssl comes from vcpkg or system
+# cryptopp-static comes from vcpkg or system
+# cryptopp_pem comes from local source tree
+# linking PUBLIC as we want headers from all those libs be accessible to all clients
 target_link_libraries(${LIB_NAME}
-    PUBLIC 
+    PUBLIC
     OpenSSL::SSL
-    cryptopp-static
+    ${CRYPTOPP_LIBRARIES}
     cryptopp_pem
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,8 +28,6 @@ add_library(${LIB_NAME} STATIC
     include/ByteSerializers/BaseByteSerializer.cpp
 )
 
-message("CRYPTOPP_LIBRARIES:" ${CRYPTOPP_LIBRARIES})
-
 # openssl comes from vcpkg or system
 # cryptopp-static comes from vcpkg or system
 # cryptopp_pem comes from local source tree

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(${BINARY}
     DeployItemByteSerializerTest.cpp
 )
 
-target_link_libraries(${BINARY} PUBLIC ${LIB_NAME} cryptopp-static)
+target_link_libraries(${BINARY} PUBLIC ${LIB_NAME} ${CRYPTOPP_LIBRARIES})
 
 add_test(NAME ${BINARY} COMMAND ./${BINARY})
 


### PR DESCRIPTION
Compilation adjustments for libcsprrpc:
1. Fixes in CMakeLists.txt
- `cryptopp-static` -> `${CRYPTOPP_LIBRARIES}`
- `find_package(cryptopp CONFIG REQUIRED)` -> `find_package(CryptoPP REQUIRED)`
- order of commands

2. Adjustements for bitwise operations on enums